### PR TITLE
Fix 'serviceEndpoint' property name.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1242,7 +1242,7 @@ The value of the <code>services</code> property should be an array of service en
   </li>
 
   <li>
-Each service endpoint must include <code>type</code> and <code>endpoint</code> properties, and may include additional properties.
+Each service endpoint must include <code>type</code> and <code>serviceEndpoint</code> properties, and may include additional properties.
   </li>
 
   <li>
@@ -1251,7 +1251,7 @@ specification.
   </li>
 
   <li>
-The value of the <code>endpoint</code> property MUST be a valid URI conforming to
+The value of the <code>serviceEndpoint</code> property MUST be a valid URI conforming to
 [[RFC3986]] and normalized according to the rules in section 6 of [[RFC3986]]
 and to any normalization rules in its applicable URI scheme specification or a
 JSON-LD object.


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/peacekeeper/did-spec/pull/47.html" title="Last updated on Feb 1, 2018, 11:57 AM GMT (81d4a1f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/did-spec/47/684e5f8...peacekeeper:81d4a1f.html" title="Last updated on Feb 1, 2018, 11:57 AM GMT (81d4a1f)">Diff</a>