### PR TITLE
Allow DID methods without Update and Delete

### DIFF
--- a/index.html
+++ b/index.html
@@ -1551,7 +1551,7 @@ Proofs</a>.
 "https://en.wikipedia.org/wiki/Create,_read,_update_and_delete">CRUD</a>
        operations is performed by a client. Each operation MUST be specified to the level of detail necessary to build and test interoperable client implementations with the target system.
 
-      The specification document for a DID method that doe not support specific operations such as Update and Delete/Revoke MUST clearly specify these limitations.
+      The specification document for a DID method that doe not support specific operations such as Update and Delete/Revoke SHOULD clearly specify these limitations.
       Note that, due to the specified contents of DID Documents, these operations can effectively be used to perform all the operations required of a CKMS (cryptographic key management system), e.g.:
 
 
@@ -1608,7 +1608,7 @@ to establish proof of ownership.
 <p>
 
 
-      The DID method specification MUST specify if possible how a client can update a DID record on the target system, including all cryptographic operations necessary to establish proof of control.
+      The DID method specification SHOULD specify if possible how a client can update a DID record on the target system, including all cryptographic operations necessary to establish proof of control.
 
 
 
@@ -1621,7 +1621,7 @@ to establish proof of ownership.
 <p>
 
 
-      Although a core feature of distributed ledgers is immutability, the DID method specification MUST specify how a client can revoke a DID record on the target system if possible, including all cryptographic operations necessary to establish proof of revocation.
+      Although a core feature of distributed ledgers is immutability, the DID method specification SHOULD specify how a client can revoke a DID record on the target system if possible, including all cryptographic operations necessary to establish proof of revocation.
 
 
 

--- a/index.html
+++ b/index.html
@@ -1551,7 +1551,7 @@ Proofs</a>.
 "https://en.wikipedia.org/wiki/Create,_read,_update_and_delete">CRUD</a>
        operations is performed by a client. Each operation MUST be specified to the level of detail necessary to build and test interoperable client implementations with the target system.
 
-
+      The specification document for a DID method that doe not support specific operations such as Update and Delete/Revoke MUST clearly specify these limitations.
       Note that, due to the specified contents of DID Documents, these operations can effectively be used to perform all the operations required of a CKMS (cryptographic key management system), e.g.:
 
 
@@ -1608,7 +1608,7 @@ to establish proof of ownership.
 <p>
 
 
-      The DID method specification MUST specify how a client can update a DID record on the target system, including all cryptographic operations necessary to establish proof of control.
+      The DID method specification MUST specify if possible how a client can update a DID record on the target system, including all cryptographic operations necessary to establish proof of control.
 
 
 
@@ -1621,7 +1621,7 @@ to establish proof of ownership.
 <p>
 
 
-      Although a core feature of distributed ledgers is immutability, the DID method specification MUST specify how a client can revoke a DID record on the target system, including all cryptographic operations necessary to establish proof of revocation.
+      Although a core feature of distributed ledgers is immutability, the DID method specification MUST specify how a client can revoke a DID record on the target system if possible, including all cryptographic operations necessary to establish proof of revocation.
 
 
 


### PR DESCRIPTION
Several light weight DID methods such as the [secp256k1-did-resolver](https://github.com/uport-project/secp256k1-did-resolver) do not allow Update or Delete.

These methods are primarily intended as lightweight identities for IOT devices, temporary session identities that can intro with more permanent identities.

Change wording to allow lightweight DID methods without Update and Delete functionality


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/uport-project/did-spec/pull/55.html" title="Last updated on Mar 2, 2018, 7:06 PM GMT (47eb303)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/did-spec/55/8ea8c86...uport-project:47eb303.html" title="Last updated on Mar 2, 2018, 7:06 PM GMT (47eb303)">Diff</a>