### PR TITLE
Remove requirement that context must be the first line

### DIFF
--- a/index.html
+++ b/index.html
@@ -838,11 +838,6 @@ A DID Document MUST have exactly one top-level context statement.
   </li>
 
   <li>
-This statement MUST be the first line in the JSON object. (This is
-not strictly necessary under JSON-LD but required for DID Documents.)
-  </li>
-
-  <li>
     The key for this property MUST be <code>@context</code>.
   </li>
 


### PR DESCRIPTION
This seems to be more a restriction of implementations rather than a requirement for this spec.
JSON does not guarantee the order of fields. DID-spec could only require that context is the first line of a serialization.

Axel
This was discussed month ago and merged but now this issue is back. Why?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/AxelNennker/did-spec/pull/59.html" title="Last updated on Mar 8, 2018, 4:24 PM GMT (8109a9e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/did-spec/59/8ea8c86...AxelNennker:8109a9e.html" title="Last updated on Mar 8, 2018, 4:24 PM GMT (8109a9e)">Diff</a>