### PR TITLE
Minimal JSON-LD DID Document

### DIFF
--- a/index.html
+++ b/index.html
@@ -510,14 +510,13 @@ Capabilities document. The current consensus is to use object capabilities
 when possible to express authorization to modify a DID Document.
 </p>
 
-<pre class="example nohighlight" title="Minimal self-managed DID Document">
+<pre class="example nohighlight" title="Minimal self-managed JSON-LD DID Document">
 {
   "@context": "https://w3id.org/did/v1",
   "id": "did:example:123456789abcdefghi",
   "publicKey": [{
     "id": "did:example:123456789abcdefghi#keys-1",
     "type": "RsaVerificationKey2018",
-    "owner": "did:example:123456789abcdefghi",
     "publicKeyPem": "-----BEGIN PUBLIC KEY...END PUBLIC KEY-----\r\n"
   }],
   "authentication": [{


### PR DESCRIPTION
Owner is not needed as it defaults to the subject.
Also this is an example of a JSON-LD DID Document not a general DID Document which can be any JSON document.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/AxelNennker/did-spec/pull/65.html" title="Last updated on Mar 12, 2018, 2:46 PM GMT (20fd0d4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/did-spec/65/b0f2168...AxelNennker:20fd0d4.html" title="Last updated on Mar 12, 2018, 2:46 PM GMT (20fd0d4)">Diff</a>