### PR TITLE
Resolvers MUST NOT return properties if signature validation fails

### DIFF
--- a/index.html
+++ b/index.html
@@ -1657,7 +1657,8 @@ is signed.
   </li>
 
   <li>
-MAY offer the service of returning requested properties of the DID Document.
+MAY offer the service of returning requested properties of the DID Document. If this service is offered and the DID Document is
+signed then property values MUST only be returned if the signature is valid - otherwise an error MUST be returned.
   </li>
 </ol>
 

--- a/index.html
+++ b/index.html
@@ -1660,6 +1660,9 @@ is signed.
 MAY offer the service of returning requested properties of the DID Document. If this service is offered and the DID Document is
 signed then property values MUST only be returned if the signature is valid - otherwise an error MUST be returned.
   </li>
+  <li>
+If this service is offered and the DID Document can not be verified per the rules in the corresponding DID Method Specification,
+then the Resolver MUST return an error.
 </ol>
 
 </section>
@@ -1682,6 +1685,9 @@ signed then property values MUST only be returned if the signature is valid - ot
       For their part, the DLTs hosting DIDs and DID Documents have special security properties for preventing active attacks. Their design uses public/private key cryptography to allow operation on passively monitored networks without risking compromise of private keys. This is what makes DID architecture and decentralized identity possible.
 
 
+      Validating the signature of the DID document and returning properties of the DID must ensure that the signature validating
+      algorithm and the service returning properties return exactly those properties that are covered by the valid signature.
+      Separating signature validation and property extraction repeatedly lead to security vulnerabilities in the past.
 </p>
 
 <section>


### PR DESCRIPTION
Resolvers MUST NOT return DID Document properties if signature validation fails


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/AxelNennker/did-spec/pull/66.html" title="Last updated on Apr 3, 2018, 7:43 AM GMT (550ee69)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/did-spec/66/b0f2168...AxelNennker:550ee69.html" title="Last updated on Apr 3, 2018, 7:43 AM GMT (550ee69)">Diff</a>