### PR TITLE
Update RWoT leadership team

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,8 +135,7 @@ endorsement should be inferred.
 <p>
 Work on this specification has also been supported by the Rebooting the
 Web of Trust community facilitated by Christopher Allen, Shannon Appelcline,
-Kiara Robles, Brian Weller, Betty Dhamers, Kaliya Young, Manu Sporny,
-Drummond Reed, and Joe Andrieu.
+Kaliya Young, Manu Sporny, Drummond Reed, Joe Andrieu, Heather Vescent and Kim Hamilton Duffy.
 </p>
 
 </section>


### PR DESCRIPTION
Per recent discussions, we need to update the rebooting web of trust leadership team for current and future drafts. The key changes are:
1. Added Heather Vescent (checking with her that's the version of her name she wants to use) and myself
2. Remove people not currently part of leadership team. Tell me if I removed anyone that should remain; these are just the folks I haven't seen in rebooting over the past year.

Question: what is the ordering used here?