### PR TITLE
Example OpenID Connect version 1.0 instead of 3.1.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1343,7 +1343,7 @@ rules in its applicable URI scheme specification.
 {
   "service": [{
     "id": "did:example:123456789abcdefghi;openid",
-    "type": "OpenIdConnectVersion3.1Service",
+    "type": "OpenIdConnectVersion1.0Service",
     "serviceEndpoint": "https://openid.example.com/"
   }, {
     "id": "did:example:123456789abcdefghi;vcr",
@@ -2390,7 +2390,7 @@ A future-facing real-world context is provided below:
   }],
 
   "service": [{
-    "type": "OpenIdConnectVersion3.1Service",
+    "type": "OpenIdConnectVersion1.0Service",
     "serviceEndpoint": "https://openid.example.com/"
   }, {
     "type": "CredentialRepositoryService",


### PR DESCRIPTION
@dmitrizagidulin and I were wondering about this while working on https://github.com/WebOfTrustInfo/rebooting-the-web-of-trust-spring2018/blob/master/draft-documents/did_auth_draft.md. OpenID Connect version is 1.0.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/did-spec/pull/89.html" title="Last updated on Jun 10, 2018, 6:50 AM GMT (c689c27)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/did-spec/89/f6ebf04...c689c27.html" title="Last updated on Jun 10, 2018, 6:50 AM GMT (c689c27)">Diff</a>