### PR TITLE
Clarify expiration semantics

### DIFF
--- a/index.html
+++ b/index.html
@@ -2225,11 +2225,10 @@ Key and Signature Expiration
 In a decentralized identifier architecture, there are no centralized
 authorities to enforce key or signature expiration policies.
 Therefore DID resolvers and other client applications SHOULD validate
-that keys have not expired. Since some use cases may have legitimate
-reasons why already-expired keys can be extended, a key expiration
-SHOULD NOT prevent any further use of the key, and implementations
-SHOULD attempt to update its status upon encountering it in a
-signature.
+that keys were not expired at the time they were used. Since some use cases
+may have legitimate reasons why already-expired keys can be extended, a key
+expiration SHOULD NOT prevent any further use of the key, and implementations
+of a resolver SHOULD be compatible with such extension behavior.
       </p>
     </section>
 


### PR DESCRIPTION
Signed-off-by: Daniel Hardman <daniel.hardman@gmail.com>

If I receive a message that supposedly originated from X three months ago, verifying that the key for X has not expired today is not helpful; what I need to know is whether it had expired three months ago.

Also, I tried to clarify what implementation (the resolvers) should be compatible with extending-an-expired-key semantics.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dhh1128/did-spec/pull/98.html" title="Last updated on Aug 23, 2018, 1:47 AM GMT (432c905)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/did-spec/98/6c50ae4...dhh1128:432c905.html" title="Last updated on Aug 23, 2018, 1:47 AM GMT (432c905)">Diff</a>