### PR TITLE
removed confusing section about keys and DID ownership

### DIFF
--- a/index.html
+++ b/index.html
@@ -1108,14 +1108,7 @@ keys may play a role in authorization mechanisms of DID CRUD
 operations (see Section <a href="#did-operations"></a>); This may be
 defined by DID Method specifications.
       </p>
-
-      <p>
-The primary intention is that a DID Document lists public keys whose
-corresponding private keys are controlled by the entity identified by
-the DID ("owned" public keys). However, a DID Document MAY also list
-        "non-owned" public keys.
-      </p>
-
+      
       <p>
 If a public key does not exist in the DID Document, it MUST be
 assumed the key has been revoked or is invalid. The DID Document MAY


### PR DESCRIPTION
Resolves https://github.com/w3c-ccg/did-spec/issues/108


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/did-spec/pull/109.html" title="Last updated on Oct 12, 2018, 6:47 PM GMT (b488077)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/did-spec/109/4b0d5e9...b488077.html" title="Last updated on Oct 12, 2018, 6:47 PM GMT (b488077)">Diff</a>