### PR TITLE
make DID document deterministic

### DIFF
--- a/index.html
+++ b/index.html
@@ -1168,22 +1168,25 @@ Example:
   "@context": ["https://w3id.org/did/v1", "https://w3id.org/security/v1"],
   "id": "did:example:123456789abcdefghi",
   ...
-  "publicKey": [{
-    "id": "did:example:123456789abcdefghi#keys-1",
-    "type": "RsaVerificationKey2018",
-    "owner": "did:example:123456789abcdefghi",
-    "publicKeyPem": "-----BEGIN PUBLIC KEY...END PUBLIC KEY-----\r\n"
+   "publicKey": {
+    "keys-1": {
+      "type": "RsaVerificationKey2018",
+      "owner": "did:example:123456789abcdefghi",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY...END PUBLIC KEY-----\r\n", 
+      "status" : "revoked"
+  }, 
+    "keys-2" : { 
+      "type": "Ed25519VerificationKey2018",
+      "owner": "did:example:pqrstuvwxyz0987654321",
+      "publicKeyBase58": "H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"
+    }, 
   }, {
-    "id": "did:example:123456789abcdefghi#keys-2",
-    "type": "Ed25519VerificationKey2018",
-    "owner": "did:example:pqrstuvwxyz0987654321",
-    "publicKeyBase58": "H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"
-  }, {
-    "id": "did:example:123456789abcdefghi#keys-3",
-    "type": "Secp256k1VerificationKey2018",
-    "owner": "did:example:123456789abcdefghi",
-    "publicKeyHex": "02b97c30de767f084ce3080168ee293053ba33b235d7116a3263d29f1450936b71"
-  }],
+    "keys-3" : { 
+      "type": "Secp256k1VerificationKey2018",
+      "owner": "did:example:123456789abcdefghi",
+      "publicKeyHex": "02b97c30de767f084ce3080168ee293053ba33b235d7116a3263d29f1450936b71"
+    }
+  },
   ...
 }
 </pre>

--- a/index.html
+++ b/index.html
@@ -928,10 +928,6 @@ A DID Document MUST have exactly one top-level context statement.
 The key for this property MUST be <code>@context</code>.
         </li>
 
-        <li>
-The value of this key MUST be the URL for the generic DID context:
-<code>https://w3id.org/did/v1</code>.
-        </li>
       </ol>
 
       <p>


### PR DESCRIPTION
This seems like a very w3c centric view of the world that the `@context `must be a URL.  I think there are better solutions, including `@context `being and object ( still valid).  Also checkout this argument for why I think IPLD is a more secure solution:  https://github.com/jonnycrunch/rwot7/blob/master/draft-documents/ipld_did_documents.md.  

`@context` with root path should be valid as a self-describing cryptographic link.  i.e.:  

`{ "@context" : 
    { "/" : "zdpuAmoZixxJjvosviGeYcqduzDhSwGV2bL6ZTTXo1hbEJHfq" }
}`


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jonnycrunch/did-spec/pull/110.html" title="Last updated on Jan 29, 2019, 10:27 PM UTC (bb462e9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/did-spec/110/4b0d5e9...jonnycrunch:bb462e9.html" title="Last updated on Jan 29, 2019, 10:27 PM UTC (bb462e9)">Diff</a>