### PR TITLE
Clarify PubKey section

### DIFF
--- a/index.html
+++ b/index.html
@@ -1122,39 +1122,39 @@ detail how revocation is performed and tracked.
 The rules for public keys are:
       </p>
 
-      <ol start="1">
-        <li>
-A DID Document MAY include a <code>publicKey</code> property.
-        </li>
+<ol start="1">
+  <li>
+A DID Document MAY include a <code>publicKey</code>
+property.
+  </li>
 
-        <li>
-The value of the <code>publicKey</code> property should be an
-array of public keys.
-        </li>
+  <li>
+The value of the <code>publicKey</code> property MUST be an
+array of public keys. 
+  </li>
 
-        <li>
-Each public key must include <code>id</code> and
-        <code>type</code> properties, and exactly one value property.
-        </li>
+  <li>
+Each public key MUST include <code>id</code> and
+<code>type</code> properties, and exactly one value property. The array of public keys SHOULD NOT contain duplicate entries
+    with the same <code>id</code> and different value properties with different formats.
+  </li>
 
-        <li>
-Each public key may include an <code>controller</code> property, which
-identifies the entity that controls the corresponding private key. If
-this property is missing, it is assumed to be the DID subject.
-        </li>
+  <li>
+Each public key MUST include a <code>controller</code> property, which identifies the entity that controls
+the corresponding private key. If this property is missing, it is assumed to be the DID subject.
+  </li>
 
-        <li>
-The value property of a public key may be
-        <code>publicKeyPem</code>, <code>publicKeyJwk</code>,
-        <code>publicKeyHex</code>, <code>publicKeyBase64</code> or similar,
-depending on the format and encoding of the public key.
-        </li>
+  <li>
+The value property of a public key MUST be exactly one of
+<code>publicKeyPem</code>, <code>publicKeyJwk</code>, <code>publicKeyHex</code>, <code>publicKeyBase64</code>, <code>publicKeyBase58</code>, or similar
+depending on the format and encoding of the public key. 
+  </li>
 
-        <li>
-A registry of key types and formats is available in Appendix
-<a href="#registries"></a>.
-        </li>
-      </ol>
+  <li>
+A registry of key types and formats is available in
+Appendix <a href="#registries"></a>.
+  </li>
+</ol>
 
       <p>
 Example:

--- a/index.html
+++ b/index.html
@@ -1124,35 +1124,38 @@ The rules for public keys are:
 
       <ol start="1">
         <li>
-A DID Document MAY include a <code>publicKey</code>
-property.
+A DID Document MAY include a <code>publicKey</code> property.
         </li>
 
         <li>
-The value of the <code>publicKey</code> property MUST be an
-array of public keys. 
+The value of the <code>publicKey</code> property MUST be an array of 
+public keys. 
         </li>
 
         <li>
-Each public key MUST include <code>id</code> and
-<code>type</code> properties, and exactly one value property. The array of public keys SHOULD NOT contain duplicate entries
-    with the same <code>id</code> and different value properties with different formats.
+Each public key MUST include <code>id</code> and <code>type</code> 
+properties, and exactly one value property. The array of public keys 
+SHOULD NOT contain duplicate entries with the same <code>id</code> and 
+different value properties with different formats.
         </li>
 
         <li>
-Each public key MUST include a <code>controller</code> property, which identifies the entity that controls
-the corresponding private key. If this property is missing, it is assumed to be the DID subject.
+Each public key MUST include a <code>controller</code> property, which 
+identifies the entity that controls the corresponding private key. If 
+this property is missing, it is assumed to be the DID subject.
         </li>
 
         <li>
 The value property of a public key MUST be exactly one of
-<code>publicKeyPem</code>, <code>publicKeyJwk</code>, <code>publicKeyHex</code>, <code>publicKeyBase64</code>, <code>publicKeyBase58</code>, or similar
-depending on the format and encoding of the public key. 
+<code>publicKeyPem</code>, <code>publicKeyJwk</code>, 
+<code>publicKeyHex</code>, <code>publicKeyBase64</code>, 
+<code>publicKeyBase58</code>, or similar depending on the format and 
+encoding of the public key. 
         </li>
 
         <li>
-A registry of key types and formats is available in
-Appendix <a href="#registries"></a>.
+A registry of key types and formats is available in Appendix 
+<a href="#registries"></a>.
         </li>
       </ol>
 

--- a/index.html
+++ b/index.html
@@ -1122,39 +1122,39 @@ detail how revocation is performed and tracked.
 The rules for public keys are:
       </p>
 
-<ol start="1">
-  <li>
+      <ol start="1">
+        <li>
 A DID Document MAY include a <code>publicKey</code>
 property.
-  </li>
+        </li>
 
-  <li>
+        <li>
 The value of the <code>publicKey</code> property MUST be an
 array of public keys. 
-  </li>
+        </li>
 
-  <li>
+        <li>
 Each public key MUST include <code>id</code> and
 <code>type</code> properties, and exactly one value property. The array of public keys SHOULD NOT contain duplicate entries
     with the same <code>id</code> and different value properties with different formats.
-  </li>
+        </li>
 
-  <li>
+        <li>
 Each public key MUST include a <code>controller</code> property, which identifies the entity that controls
 the corresponding private key. If this property is missing, it is assumed to be the DID subject.
-  </li>
+        </li>
 
-  <li>
+        <li>
 The value property of a public key MUST be exactly one of
 <code>publicKeyPem</code>, <code>publicKeyJwk</code>, <code>publicKeyHex</code>, <code>publicKeyBase64</code>, <code>publicKeyBase58</code>, or similar
 depending on the format and encoding of the public key. 
-  </li>
+        </li>
 
-  <li>
+        <li>
 A registry of key types and formats is available in
 Appendix <a href="#registries"></a>.
-  </li>
-</ol>
+        </li>
+      </ol>
 
       <p>
 Example:

--- a/index.html
+++ b/index.html
@@ -1105,7 +1105,7 @@ such as authentication (see Section <a href="#authentication"></a>)
 or establishing secure communication with <a>service endpoints</a>
         (see Section <a href="#service-endpoints"></a>). In addition, public
 keys may play a role in authorization mechanisms of DID CRUD
-operations (see Section <a href="#did-operations"></a>); This may be
+operations (see Section <a href="#did-operations"></a>). This may be
 defined by DID Method specifications.
       </p>
       

--- a/index.html
+++ b/index.html
@@ -1149,7 +1149,7 @@ this property is missing, it is assumed to be the DID subject.
 The value property of a public key MUST be exactly one of
 <code>publicKeyPem</code>, <code>publicKeyJwk</code>, 
 <code>publicKeyHex</code>, <code>publicKeyBase64</code>, 
-<code>publicKeyBase58</code>, or similar depending on the format and 
+<code>publicKeyBase58</code>, <code>publicKeyMultibase</code>, or similar depending on the format and 
 encoding of the public key. 
         </li>
 


### PR DESCRIPTION
Cherry picks from https://github.com/w3c-ccg/did-spec/pull/61 to incorporate feedback in the discussion. 

Ready to merge now, but I have an additional proposal to clarify the "vague" text around value properties (https://github.com/w3c-ccg/did-spec/pull/61#discussion_r178646041), which is to move anything around key formats to 5., ie:

> 3. Each public key MUST include `id` and `type` properties.
> 4. ...
> 5. Each public key MUST contain exactly one key with a value of one of: `publicKeyPem`, `publicKeyJwk`, `publicKeyHex`, `publicKeyBase64`, `publicKeyBase58`, or similar depending on the format and encoding of the public key. The array of public keys SHOULD NOT contain duplicate entries with the same `id` and different formats.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/did-spec/pull/162.html" title="Last updated on Jan 26, 2019, 8:38 PM UTC (ed66265)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/did-spec/162/dfdac17...ed66265.html" title="Last updated on Jan 26, 2019, 8:38 PM UTC (ed66265)">Diff</a>