### PR TITLE
Refactor ABNF rules for DIDs and DID References.

### DIFF
--- a/index.html
+++ b/index.html
@@ -534,7 +534,7 @@ Document.
     "publicKeyPem": "-----BEGIN PUBLIC KEY...END PUBLIC KEY-----\r\n"
   }],
   "service": [{
-    "id": "#service123",
+    "id": "did:example:123456789abcdefghi#service123",
     "type": "ExampleService",
     "serviceEndpoint": "https://example.com/endpoint/8377464"
   }]
@@ -1423,31 +1423,31 @@ Example:
       <pre class="example nohighlight" title="Various service endpoints">
 {
   "service": [{
-    "id": "#openid",
+    "id": "did:example:123456789abcdefghi#openid",
     "type": "OpenIdConnectVersion1.0Service",
     "serviceEndpoint": "https://openid.example.com/"
   }, {
-    "id": "#vcr",
+    "id": "did:example:123456789abcdefghi#vcr",
     "type": "CredentialRepositoryService",
     "serviceEndpoint": "https://repository.example.com/service/8377464"
   }, {
-    "id": "#xdi",
+    "id": "did:example:123456789abcdefghi#xdi",
     "type": "XdiService",
     "serviceEndpoint": "https://xdi.example.com/8377464"
   }, {
-    "id": "#agent",
+    "id": "did:example:123456789abcdefghi#agent",
     "type": "AgentService",
     "serviceEndpoint": "https://agent.example.com/8377464"
   }, {
-    "id": "#hub",
+    "id": "did:example:123456789abcdefghi#hub",
     "type": "HubService",
     "serviceEndpoint": "https://hub.example.com/.identity/did:example:0123456789abcdef/"
   }, {
-    "id": "#messages",
+    "id": "did:example:123456789abcdefghi#messages",
     "type": "MessagingService",
     "serviceEndpoint": "https://example.com/messages/8377464"
   }, {
-    "id": "#inbox",
+    "id": "did:example:123456789abcdefghi#inbox",
     "type": "SocialWebInboxService",
     "serviceEndpoint": "https://social.example.com/83hfh37dj",
     "description": "My public social inbox",
@@ -1456,7 +1456,7 @@ Example:
       "currency": "USD"
     }
   }, {
-    "id": "#authpush",
+    "id": "did:example:123456789abcdefghi#authpush",
     "type": "DidAuthPushModeVersion1",
     "serviceEndpoint": "http://auth.example.com/did:example:123456789abcdefg"
   }]
@@ -1720,7 +1720,7 @@ context above and adding the new property to the <a>DID Document</a>.
   "authentication": [ ... ],
   "service": [<span class="highlight">{
     "@context": "did:example:contexts:987654321",
-    "id": "#photos",
+    "id": "did:example:123456789abcdefghi#photos",
     "type": "PhotoStreamService",
     "serviceEndpoint": "https://example.org/photos/379283"
   }</span>]

--- a/index.html
+++ b/index.html
@@ -819,7 +819,7 @@ The method name MUST be lowercase.
 
         <li>
 Case sensitivity and normalization of the value of the
-specific-idstring rule in Section <a href="#the-generic-did-scheme">
+<pre>method-specific-idstring</pre> rule in Section <a href="#the-generic-did-scheme">
           </a> MUST be defined by the governing DID method specification.
         </li>
       </ol>
@@ -1789,7 +1789,7 @@ DID Method Schemes
 
       <p>
 A DID method specification MUST define exactly one specific DID
-scheme identified by exactly one method name (the method rule in
+scheme identified by exactly one method name (the <pre>method</pre> rule in
 Section <a href="#the-generic-did-scheme"></a>). Since DIDs are
 intended for decentralized identity infrastructure, it is NOT
 RECOMMENDED to establish a registry of unique DID method names.
@@ -1813,18 +1813,19 @@ network to which the DID method specification applies.
 
       <p>
 The DID method specification for the specific DID scheme MUST specify
-how to generate the specific-idstring component of a DID. The
-specific-idstring value MUST be able to be generated without the use
-of a centralized registry service. The specific-idstring value SHOULD
-be globally unique by itself. The fully qualified DID as defined by
-the DID rule in Section <a href="#the-generic-did-scheme"></a> MUST
-be globally unique.
+how to generate the <pre>method-specific-idstring</pre> component of a DID. The
+<pre>method-specific-idstring</pre> value MUST be able to be generated without
+the use of a centralized registry service. The
+<pre>method-specific-idstring</pre> value SHOULD be globally unique by itself.
+The DID as defined by the <pre>did</pre> rule in Section
+<a href="#the-generic-did-scheme"></a> MUST be globally unique.
       </p>
 
       <p>
-If needed, a specific DID scheme MAY define multiple specific
-specific-idstring formats. It is RECOMMENDED that a specific DID
-scheme define as few specific-idstring formats as possible.
+If needed, a specific DID scheme MAY define multiple
+<pre>method-specific-idstring</pre> formats. It is RECOMMENDED that a specific
+DID scheme define as few <pre>method-specific-idstring</pre> formats as
+possible.
       </p>
     </section>
 

--- a/index.html
+++ b/index.html
@@ -778,7 +778,7 @@ service-id         = ALPHA / DIGIT / "." / "-" / "_"
 
       <section>
         <h3>
-      DID Reference Service Paths, Queries and Fragments
+      DID Reference Service Paths, Queries, and Fragments
         </h3>
 
       <p>

--- a/index.html
+++ b/index.html
@@ -736,7 +736,9 @@ portable way to refer to Service Endpoint resources, queries and fragments.
       </p>
 
       <pre class="nohighlight">
-did-reference      = did [ "#" did-fragment ] [";" service-id] [ "/" service-path ] [ "?" service-query ] [ "#" service-fragment ]
+did-reference      = did (did-fragment-reference / did-service-reference)
+did-fragment-reference  = "#" did-fragment
+did-service-reference   = ";" service-id] [ "/" service-path ] [ "?" service-query ] [ "#" service-fragment ]
 service-id         = ALPHA / DIGIT / "." / "-" / "_"
       </pre>
 

--- a/index.html
+++ b/index.html
@@ -730,53 +730,63 @@ idchar             = ALPHA / DIGIT / "." / "-"
 DID Reference
       </h2>
 
+      <p>DID References are used for two main purposes: to refer to sections
+inside a DID Document (via <a href="#did-fragments">DID Fragments</a>), and as a
+portable way to refer to Service Endpoint resources, queries and fragments.
+      </p>
+
       <pre class="nohighlight">
 did-reference      = did [ "#" did-fragment ] [";" service-id] [ "/" service-path ] [ "?" service-query ] [ "#" service-fragment ]
 service-id         = ALPHA / DIGIT / "." / "-" / "_"
       </pre>
 
+      <section>
+        <h3>
+  DID Fragments
+        </h3>
+
+        <p>
+  A generic <a>DID fragment</a> (the did-fragment rule in Section
+  <a href="#did-reference"></a>) is identical to a URI
+  fragment and MUST conform to the ABNF of the fragment ABNF rule in
+  [[RFC3986]]. A DID fragment MUST be used only as a method-independent
+  pointer into the DID Document to identify a unique key description or
+  other DID Document component. To resolve this pointer, the complete
+  DID reference including the DID fragment MUST be used as the value of
+  the id key for the target JSON object.
+        </p>
+
+        <p>
+  A specific DID scheme MAY specify ABNF rules for DID fragments that
+  are more restrictive than the generic rules in this section.
+        </p>
+
+        <p>
+  It is desirable that we enable tree-based processing of DIDs that include
+  DID fragments (which resolve directly within the DID document) to locate
+  metadata contained directly in the DID document or the service resource
+  given by the target URL without needing to rely on graph-based processing.
+        </p>
+        <p>
+  Implementations SHOULD NOT prevent the use of JSON pointers ([[RFC6901]]).
+        </p>
+      </section>
+
+      <section>
+        <h3>
+      DID Reference Service Paths, Queries and Fragments
+        </h3>
+
       <p>
-A DID path (the <pre>service-path</pre> rule above) is identical
-to a URI path and MUST conform to the ABNF of the path-rootless ABNF rule in
-[[RFC3986]]. A DID path is used to address resources available via a DID
+A DID Reference Service path (the <pre>service-path</pre> rule above) is
+identical to a URI path and MUST conform to the ABNF of the path-rootless ABNF
+rule in [[RFC3986]]. A DID path is used to address resources available via a DID
 service endpoint. See Section <a href="#service-endpoints"></a>.
       </p>
 
       <p>
-A specific DID scheme MAY specify ABNF rules for DID paths that are
-more restrictive than the generic rules in this section.
-      </p>
-    </section>
-
-    <section>
-      <h2>
-Fragments
-      </h2>
-
-      <p>
-A generic <a>DID fragment</a> (the did-fragment rule in Section
-<a href="#did-reference"></a>) is identical to a URI
-fragment and MUST conform to the ABNF of the fragment ABNF rule in
-[[RFC3986]]. A DID fragment MUST be used only as a method-independent
-pointer into the DID Document to identify a unique key description or
-other DID Document component. To resolve this pointer, the complete
-DID reference including the DID fragment MUST be used as the value of
-the id key for the target JSON object.
-      </p>
-
-      <p>
-A specific DID scheme MAY specify ABNF rules for DID fragments that
-are more restrictive than the generic rules in this section.
-      </p>
-
-      <p>
-It is desirable that we enable tree-based processing of DIDs that include
-DID fragments (which resolve directly within the DID document) to locate
-metadata contained directly in the DID document or the service resource
-given by the target URL without needing to rely on graph-based processing.
-      </p>
-      <p>
-Implementations SHOULD NOT prevent the use of JSON pointers ([[RFC6901]]).
+A specific DID scheme MAY specify ABNF rules for DID Reference service paths
+that are more restrictive than the generic rules in this section.
       </p>
     </section>
 

--- a/index.html
+++ b/index.html
@@ -748,7 +748,7 @@ service-id         = ALPHA / DIGIT / "." / "-" / "_"
         </h3>
 
         <p>
-  A generic <a>DID fragment</a> (the <pre>did-fragment</pre> rule in Section
+  A generic <a>DID fragment</a> (the <code>did-fragment</code> rule in Section
   <a href="#did-reference"></a>) is identical to a URI
   fragment and MUST conform to the ABNF of the fragment ABNF rule in
   [[RFC3986]]. A DID fragment MUST be used only as a method-independent
@@ -780,7 +780,7 @@ service-id         = ALPHA / DIGIT / "." / "-" / "_"
         </h3>
 
       <p>
-A DID Reference Service path (the <pre>service-path</pre> rule above) is
+A DID Reference Service path (the <code>service-path</code> rule above) is
 identical to a URI path and MUST conform to the ABNF of the path-rootless ABNF
 rule in [[RFC3986]]. The path is used to address resources available via a DID
 service endpoint. See Section <a href="#service-endpoints"></a>.
@@ -792,7 +792,7 @@ that are more restrictive than the generic rules in this section.
       </p>
 
       <p>
-A DID Reference Service <pre>query</pre> and <pre>fragment</pre> parts are
+A DID Reference Service <code>query</code> and <code>fragment</code> parts are
 identical to their URI counterparts and MUST conform to the ABNF of the query
 and fragment rules in [[RFC3986]].
       </p>
@@ -819,7 +819,7 @@ The method name MUST be lowercase.
 
         <li>
 Case sensitivity and normalization of the value of the
-<pre>method-specific-idstring</pre> rule in Section <a href="#the-generic-did-scheme">
+<code>method-specific-idstring</code> rule in Section <a href="#the-generic-did-scheme">
           </a> MUST be defined by the governing DID method specification.
         </li>
       </ol>
@@ -1789,7 +1789,7 @@ DID Method Schemes
 
       <p>
 A DID method specification MUST define exactly one specific DID
-scheme identified by exactly one method name (the <pre>method</pre> rule in
+scheme identified by exactly one method name (the <code>method</code> rule in
 Section <a href="#the-generic-did-scheme"></a>). Since DIDs are
 intended for decentralized identity infrastructure, it is NOT
 RECOMMENDED to establish a registry of unique DID method names.
@@ -1813,18 +1813,18 @@ network to which the DID method specification applies.
 
       <p>
 The DID method specification for the specific DID scheme MUST specify
-how to generate the <pre>method-specific-idstring</pre> component of a DID. The
-<pre>method-specific-idstring</pre> value MUST be able to be generated without
+how to generate the <code>method-specific-idstring</code> component of a DID. The
+<code>method-specific-idstring</code> value MUST be able to be generated without
 the use of a centralized registry service. The
-<pre>method-specific-idstring</pre> value SHOULD be globally unique by itself.
-The DID as defined by the <pre>did</pre> rule in Section
+<code>method-specific-idstring</code> value SHOULD be globally unique by itself.
+The DID as defined by the <code>did</code> rule in Section
 <a href="#the-generic-did-scheme"></a> MUST be globally unique.
       </p>
 
       <p>
 If needed, a specific DID scheme MAY define multiple
-<pre>method-specific-idstring</pre> formats. It is RECOMMENDED that a specific
-DID scheme define as few <pre>method-specific-idstring</pre> formats as
+<code>method-specific-idstring</code> formats. It is RECOMMENDED that a specific
+DID scheme define as few <code>method-specific-idstring</code> formats as
 possible.
       </p>
     </section>

--- a/index.html
+++ b/index.html
@@ -782,7 +782,8 @@ service-id         = ALPHA / DIGIT / "." / "-" / "_"
         </h3>
 
       <p>
-A DID Reference Service path (the <code>service-path</code> rule above) is
+A DID Reference service path (the <code>service-path</code> rule in Section
+<a href="#did-reference"></a>) is
 identical to a URI path and MUST conform to the ABNF of the path-rootless ABNF
 rule in [[RFC3986]]. The path is used to address resources available via a DID
 service endpoint. See Section <a href="#service-endpoints"></a>.

--- a/index.html
+++ b/index.html
@@ -534,6 +534,7 @@ Document.
     "publicKeyPem": "-----BEGIN PUBLIC KEY...END PUBLIC KEY-----\r\n"
   }],
   "service": [{
+    "id": "#service123",
     "type": "ExampleService",
     "serviceEndpoint": "https://example.com/endpoint/8377464"
   }]
@@ -1422,31 +1423,31 @@ Example:
       <pre class="example nohighlight" title="Various service endpoints">
 {
   "service": [{
-    "id": "did:example:123456789abcdefghi;openid",
+    "id": "#openid",
     "type": "OpenIdConnectVersion1.0Service",
     "serviceEndpoint": "https://openid.example.com/"
   }, {
-    "id": "did:example:123456789abcdefghi;vcr",
+    "id": "#vcr",
     "type": "CredentialRepositoryService",
     "serviceEndpoint": "https://repository.example.com/service/8377464"
   }, {
-    "id": "did:example:123456789abcdefghi;xdi",
+    "id": "#xdi",
     "type": "XdiService",
     "serviceEndpoint": "https://xdi.example.com/8377464"
   }, {
-    "id": "did:example:123456789abcdefghi;agent",
+    "id": "#agent",
     "type": "AgentService",
     "serviceEndpoint": "https://agent.example.com/8377464"
   }, {
-    "id": "did:example:123456789abcdefghi;hub",
+    "id": "#hub",
     "type": "HubService",
     "serviceEndpoint": "https://hub.example.com/.identity/did:example:0123456789abcdef/"
   }, {
-    "id": "did:example:123456789abcdefghi;messages",
+    "id": "#messages",
     "type": "MessagingService",
     "serviceEndpoint": "https://example.com/messages/8377464"
   }, {
-    "id": "did:example:123456789abcdefghi;inbox",
+    "id": "#inbox",
     "type": "SocialWebInboxService",
     "serviceEndpoint": "https://social.example.com/83hfh37dj",
     "description": "My public social inbox",
@@ -1455,7 +1456,7 @@ Example:
       "currency": "USD"
     }
   }, {
-    "id": "did:example:123456789abcdefghi;authpush",
+    "id": "#authpush",
     "type": "DidAuthPushModeVersion1",
     "serviceEndpoint": "http://auth.example.com/did:example:123456789abcdefg"
   }]
@@ -1719,7 +1720,7 @@ context above and adding the new property to the <a>DID Document</a>.
   "authentication": [ ... ],
   "service": [<span class="highlight">{
     "@context": "did:example:contexts:987654321",
-    "id": "did:example:123456789abcdefghi;photos",
+    "id": "#photos",
     "type": "PhotoStreamService",
     "serviceEndpoint": "https://example.org/photos/379283"
   }</span>]
@@ -2642,22 +2643,28 @@ A future-facing real-world context is provided below:
   ],
 
   "service": [{
+    "id": "did:example:123456789abcdefghi#oidc",
     "type": "OpenIdConnectVersion1.0Service",
     "serviceEndpoint": "https://openid.example.com/"
   }, {
+    "id": "did:example:123456789abcdefghi#vcStore",
     "type": "CredentialRepositoryService",
     "serviceEndpoint": "https://repository.example.com/service/8377464"
   }, {
+    "id": "did:example:123456789abcdefghi#xdi",
     "type": "XdiService",
     "serviceEndpoint": "https://xdi.example.com/8377464"
   }, {
+    "id": "did:example:123456789abcdefghi#hub",
     "type": "HubService",
     "serviceEndpoint": "https://hub.example.com/.identity/did:example:0123456789abcdef/"
   }, {
+    "id": "did:example:123456789abcdefghi#messaging",
     "type": "MessagingService",
     "serviceEndpoint": "https://example.com/messages/8377464"
   }, {
     "type": "SocialWebInboxService",
+    "id": "did:example:123456789abcdefghi#inbox",
     "serviceEndpoint": "https://social.example.com/83hfh37dj",
     "description": "My public social inbox",
     "spamCost": {
@@ -2666,9 +2673,10 @@ A future-facing real-world context is provided below:
     }
   }, {
     "type": "DidAuthPushModeVersion1",
+    "id": "did:example:123456789abcdefghi#push",
     "serviceEndpoint": "http://auth.example.com/did:example:123456789abcdefghi"
   }, {
-    "id": "did:example:123456789abcdefghi;bops",
+    "id": "did:example:123456789abcdefghi#bops",
     "type": "BopsService",
     "serviceEndpoint": "https://bops.example.com/enterprise/"
   }]

--- a/index.html
+++ b/index.html
@@ -738,7 +738,7 @@ portable way to refer to Service Endpoint resources, queries and fragments.
       <pre class="nohighlight">
 did-reference      = did (did-fragment-reference / did-service-reference)
 did-fragment-reference  = "#" did-fragment
-did-service-reference   = ";" service-id] [ "/" service-path ] [ "?" service-query ] [ "#" service-fragment ]
+did-service-reference   = ";" service-id [ "/" service-path ] [ "?" service-query ] [ "#" service-fragment ]
 service-id         = ALPHA / DIGIT / "." / "-" / "_"
       </pre>
 
@@ -748,7 +748,7 @@ service-id         = ALPHA / DIGIT / "." / "-" / "_"
         </h3>
 
         <p>
-  A generic <a>DID fragment</a> (the did-fragment rule in Section
+  A generic <a>DID fragment</a> (the <pre>did-fragment</pre> rule in Section
   <a href="#did-reference"></a>) is identical to a URI
   fragment and MUST conform to the ABNF of the fragment ABNF rule in
   [[RFC3986]]. A DID fragment MUST be used only as a method-independent
@@ -782,13 +782,19 @@ service-id         = ALPHA / DIGIT / "." / "-" / "_"
       <p>
 A DID Reference Service path (the <pre>service-path</pre> rule above) is
 identical to a URI path and MUST conform to the ABNF of the path-rootless ABNF
-rule in [[RFC3986]]. A DID path is used to address resources available via a DID
+rule in [[RFC3986]]. The path is used to address resources available via a DID
 service endpoint. See Section <a href="#service-endpoints"></a>.
       </p>
 
       <p>
 A specific DID scheme MAY specify ABNF rules for DID Reference service paths
 that are more restrictive than the generic rules in this section.
+      </p>
+
+      <p>
+A DID Reference Service <pre>query</pre> and <pre>fragment</pre> parts are
+identical to their URI counterparts and MUST conform to the ABNF of the query
+and fragment rules in [[RFC3986]].
       </p>
     </section>
 

--- a/index.html
+++ b/index.html
@@ -795,7 +795,9 @@ that are more restrictive than the generic rules in this section.
       </p>
 
       <p>
-A DID Reference Service <code>query</code> and <code>fragment</code> parts are
+The DID Reference service query and service fragment
+(the <code>service-query</code> and <code>service-fragment</code> rules
+in Section <a href="#did-reference"></a>) parts are
 identical to their URI counterparts and MUST conform to the ABNF of the query
 and fragment rules in [[RFC3986]].
       </p>

--- a/index.html
+++ b/index.html
@@ -734,7 +734,7 @@ DID Reference
       <p>
 DID References are used for two main purposes: to refer to sections
 inside a DID Document (via <a href="#did-fragments">DID Fragments</a>), and as a
-portable way to refer to Service Endpoint resources, queries and fragments.
+portable way to refer to <a>Service Endpoint</a> resources, queries, and fragments.
       </p>
 
       <pre class="nohighlight">

--- a/index.html
+++ b/index.html
@@ -711,8 +711,8 @@ the <a href="#did-reference">DID Reference section</a> below.
       </p>
 
       <p>
-Following is the ABNF definition using the syntax in [[RFC5234]]
-        (which defines ALPHA as upper or lowercase A-Z).
+The following is the ABNF definition using the syntax in [[RFC5234]]
+which defines <code>ALPHA</code> and <code>DIGIT</code>.
       </p>
 
       <pre class="nohighlight">

--- a/index.html
+++ b/index.html
@@ -730,7 +730,8 @@ idchar             = ALPHA / DIGIT / "." / "-"
 DID Reference
       </h2>
 
-      <p>DID References are used for two main purposes: to refer to sections
+      <p>
+DID References are used for two main purposes: to refer to sections
 inside a DID Document (via <a href="#did-fragments">DID Fragments</a>), and as a
 portable way to refer to Service Endpoint resources, queries and fragments.
       </p>
@@ -819,8 +820,8 @@ The method name MUST be lowercase.
 
         <li>
 Case sensitivity and normalization of the value of the
-<code>method-specific-idstring</code> rule in Section <a href="#the-generic-did-scheme">
-          </a> MUST be defined by the governing DID method specification.
+<code>method-specific-idstring</code> rule in Section
+<a href="#the-generic-did-scheme"></a> MUST be defined by the governing DID method specification.
         </li>
       </ol>
     </section>

--- a/index.html
+++ b/index.html
@@ -702,11 +702,12 @@ The Generic DID Scheme
 
       <p>
 The generic <a>DID scheme</a> is a URI scheme conformant with
-[[RFC3986]]. It consists of a DID followed by an optional path and/or
-fragment. The term DID refers only to the identifier conforming to
-the did rule in the ABNF below; when used alone, it does not include
-a path or fragment. A DID that may optionally include a path and/or
-fragment is called a DID reference.
+[[RFC3986]]. It consists of a DID method name, followed by a method-specific
+identifier. The term DID refers only to the identifier conforming to
+the did rule in the ABNF below.
+
+Additionally, a DID can be used as a component in a DID Reference, described in
+the <a href="#did-reference">DID Reference section</a> below.
       </p>
 
       <p>
@@ -715,29 +716,29 @@ Following is the ABNF definition using the syntax in [[RFC5234]]
       </p>
 
       <pre class="nohighlight">
-did-reference      = did [ "/" did-path ] [ "#" did-fragment ]
-did                = "did:" method ":" specific-idstring
+did                = "did:" method ":" method-specific-idstring
 method             = 1*methodchar
 methodchar         = %x61-7A / DIGIT
-specific-idstring  = idstring *( ":" idstring )
+method-specific-idstring  = idstring *( ":" idstring )
 idstring           = 1*idchar
 idchar             = ALPHA / DIGIT / "." / "-"
 </pre>
-      <p>
-See Sections <a href="#paths"></a> and <a href="#fragments"></a> for the ABNF rules defining DID paths and
-fragments.
-      </p>
     </section>
 
     <section>
       <h2>
-Paths
+DID Reference
       </h2>
 
+      <pre class="nohighlight">
+did-reference      = did [ "#" did-fragment ] [";" service-id] [ "/" service-path ] [ "?" service-query ] [ "#" service-fragment ]
+service-id         = ALPHA / DIGIT / "." / "-" / "_"
+      </pre>
+
       <p>
-A generic <a>DID path</a> (the did-path rule in Section <a href="#the-generic-did-scheme"></a>) is identical to a URI path and MUST
-conform to the ABNF of the path-rootless ABNF rule in [[RFC3986]]. A
-DID path SHOULD be used to address resources available via a DID
+A DID path (the <pre>service-path</pre> rule above) is identical
+to a URI path and MUST conform to the ABNF of the path-rootless ABNF rule in
+[[RFC3986]]. A DID path is used to address resources available via a DID
 service endpoint. See Section <a href="#service-endpoints"></a>.
       </p>
 
@@ -754,7 +755,7 @@ Fragments
 
       <p>
 A generic <a>DID fragment</a> (the did-fragment rule in Section
-<a href="#the-generic-did-scheme"></a>) is identical to a URI
+<a href="#did-reference"></a>) is identical to a URI
 fragment and MUST conform to the ABNF of the fragment ABNF rule in
 [[RFC3986]]. A DID fragment MUST be used only as a method-independent
 pointer into the DID Document to identify a unique key description or
@@ -813,7 +814,7 @@ Persistence
 
       <p>
 A DID MUST be persistent and immutable, i.e., bound to an entity once
-and never changed (forever). 
+and never changed (forever).
       </p>
 
       <p>
@@ -822,7 +823,7 @@ abstract decentralized identifier (like a UUID) that could be bound
 to multiple underlying distributed ledgers or networks over time,
 thus maintaining its persistence independent of any particular ledger
 or network. However registering the same identifier on multiple
-ledgers or networks introduces extremely hard entityship and 
+ledgers or networks introduces extremely hard entityship and
 <a href="https://en.wikipedia.org/wiki/List_of_DNS_record_types%23SOA">start-of-authority</a>
 (SOA) problems. It also greatly increases implementation complexity
 for developers.


### PR DESCRIPTION
This PR integrates and reflects the current consensus on the DID ABNF rules, as well as DID Reference and Service Endpoint ABNF rules.

Specifically:

* Separates the DID Reference ABNF from the DID ABNF
* Differentiates a DID fragment from a Service fragment
* Specifies ABNF rules for did query, did path
* Clarifies use cases for DID References (service endpoints resolution, key references, etc). 
* Updates service endpoint `id:` properties in examples.

Replaces PR #106, addresses #85.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/did-spec/pull/168.html" title="Last updated on Feb 16, 2019, 6:54 PM UTC (89a234c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/did-spec/168/aeb7bc6...89a234c.html" title="Last updated on Feb 16, 2019, 6:54 PM UTC (89a234c)">Diff</a>