### PR TITLE
Add non-normative section about the DID Method Registry, re: #133

### DIFF
--- a/index.html
+++ b/index.html
@@ -2050,7 +2050,7 @@ names known to them at the time of publication.
       </p>
       <p>
 Because there is no central authority for allocating or approving DID
-methods, there is no way to know for certain if a particular DID method
+method names, there is no way to know for certain if a particular DID method
 name is unique. To help with this challenge, the
 <a href="https://www.w3.org/community/credentials/">W3C Credentials Community
 Group</a> maintains a non-authoritative list of known DID

--- a/index.html
+++ b/index.html
@@ -1926,17 +1926,6 @@ Section <a href="#the-generic-did-scheme"></a>).
       </p>
 
       <p>
-Since DIDs are intended for decentralized identity infrastructure, it is NOT
-RECOMMENDED to establish a definitive software registry of unique DID method names.
-Rather, the uniqueness of DID method names should be established via
-human consensus, i.e., a specific DID scheme MUST use a method name
-that is unique among all DID method names known to the specification
-authors at the time of publication. To facilitate this, we maintain a document
-listing known DID method names and their associated specifications (see Appendix
-<a href="#registries"></a>).
-      </p>
-
-      <p>
 Since the method name is part of the DID, it SHOULD be as short as
 practical. A method name of five characters or less is RECOMMENDED.
 The method name MAY reflect the name of the distributed ledger or
@@ -2049,6 +2038,38 @@ necessary to establish proof of deactivation.
         </p>
       </section>
     </section>
+
+    <section class="informative">
+      <h2>
+Unique DID Method Names
+      </h2>
+      <p>
+The authors of a new DID method specification are
+expected to use a method name that is unique among all DID method
+names known to them at the time of publication.
+      </p>
+      <p>
+Because there is no central authority for allocating or approving DID
+methods, there is no way to know for certain if a particular DID method
+name is unique. To help with this challenge, the
+<a href="https://www.w3.org/community/credentials/">W3C Credentials Community
+Group</a> maintains a non-authoritative list of known DID
+method names and their associated specifications (see Appendix
+<a href="#registries"></a>).
+      </p>
+      <p>
+The [[DID-METHOD-REGISTRY]] is a tool for implementors to use when coming
+to consensus on a new method name, as well as an informative reference for
+software developers implementing <a href="#did-resolvers"></a> for different
+DID methods.
+The [[DID-METHOD-REGISTRY]] is not a definitive or official list of DID
+methods. Nonetheless, adding DID method names to the [[DID-METHOD-REGISTRY]] is
+encouraged so that other implementors and members of the community have a
+place to see an overview of existing DID methods. The lightweight criteria for
+inclusion are documented in the [[DID-METHOD-REGISTRY]].
+      </p>
+    </section>
+
   </section>
 
   <section>
@@ -2712,7 +2733,7 @@ Purpose
 Method Registry</a>
           </td>
           <td>
-Defines all known DID Methods and contains links to their
+Lists all known DID Methods and contains links to their
 specifications.
           </td>
         </tr>

--- a/index.html
+++ b/index.html
@@ -2225,6 +2225,22 @@ security requirements of the supported authentication protocol.
 
     <section>
       <h2>
+Choosing DID Resolvers
+      </h2>
+
+      <p>
+The [[DID-METHOD-REGISTRY]] is an informative list of DID method names
+and their corresponding DID Method specifications.
+Implementors should bear in mind that there is no central authority to
+mandate which DID Method specification must be used with any particular
+DID Method name, but can use the [[DID-METHOD-REGISTRY]] to make an
+informed decision when choosing which <a href="#did-resolvers"></a>
+implementations to use.
+      </p>
+    </section>
+
+    <section>
+      <h2>
 Binding of Identity
       </h2>
 
@@ -2443,6 +2459,7 @@ recovery. Further specification of this type of control is a matter
 for future work (see section <a href="#time-locks-and-did-document-recovery"></a>).
       </p>
     </section>
+
   </section>
 
   <section class="informative">


### PR DESCRIPTION
A starting point; I expect people will have lots of opinions about what goes in here.

The **Unique DID Method Names** section tries to strike a balance between explaining why the DID Method Registry is useful, without implying it's authoritative or required, and without being too defensive about its existence at all.

@talltree's original proposal was to call it "Governance of DID Method Namespaces" but I thought "governance" implied a bit more authority or even just process than perhaps we want to associate with the DID Method Registry. 

Also there might be a better place in the spec for this section.

I also added a *very short* section in Security Considerations because if I understand correctly potential non-unique DID method names could be an attack vector. This might warrant expanding on in the future, but I kept it brief for now.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/did-spec/pull/186.html" title="Last updated on Jun 3, 2019, 6:51 AM UTC (48070d9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/did-spec/186/f892d6c...48070d9.html" title="Last updated on Jun 3, 2019, 6:51 AM UTC (48070d9)">Diff</a>