### PR TITLE
Update ABNF to use matrix parameters

### DIFF
--- a/common.js
+++ b/common.js
@@ -85,7 +85,7 @@ var ccg = {
       status: "CG-DRAFT",
       publisher: "Digital Verification Community Group"
     },
-    "DRAFT-SPORNY-HASHLINK-02": {
+    "HASHLINK": {
       title: "Cryptographic Hyperlinks",
       date: "December 2018",
       href: "https://tools.ietf.org/html/draft-sporny-hashlink-02",

--- a/common.js
+++ b/common.js
@@ -84,6 +84,25 @@ var ccg = {
       ],
       status: "CG-DRAFT",
       publisher: "Digital Verification Community Group"
+    },
+    "DRAFT-SPORNY-HASHLINK-02": {
+      title: "Cryptographic Hyperlinks",
+      date: "December 2018",
+      href: "https://tools.ietf.org/html/draft-sporny-hashlink-02",
+      authors: [
+        "Manu Sporny"
+      ],
+      status: "Internet-Draft",
+      publisher: "IETF"
+    },
+    "MATRIX-URIS": {
+      title: "Matrix URIs - Ideas about Web Architecture",
+      date: "December 1996",
+      href: "https://www.w3.org/DesignIssues/MatrixURIs.html",
+      authors: [
+        "Tim Berners-Lee"
+      ],
+      status: "Personal View"
     }
   }
 };

--- a/index.html
+++ b/index.html
@@ -898,7 +898,7 @@ may not be supported by all DID methods.
             </td>
             <td>
 A resource hash of the resource identified by the DID URL to add integrity
-protection, as specified in [[DRAFT-SPORNY-HASHLINK-02]].
+protection, as specified in [[HASHLINK]].
             </td>
           </tr>
 

--- a/index.html
+++ b/index.html
@@ -1062,7 +1062,7 @@ The method name MUST be lowercase.
 
         <li>
 Case sensitivity and normalization of the value of the
-specific-idstring rule in Section <a href="#generic-did-syntax">
+<code>method-specific-id</code> rule in Section <a href="#generic-did-syntax">
           </a> MUST be defined by the governing DID method specification.
         </li>
       </ol>
@@ -2171,9 +2171,9 @@ network to which the DID method specification applies.
 
       <p>
 The DID method specification for the specific DID scheme MUST specify
-how to generate the specific-idstring component of a DID. The
-specific-idstring value MUST be able to be generated without the use
-of a centralized registry service. The specific-idstring value SHOULD
+how to generate the <code>method-specific-id</code> component of a DID. The
+<code>method-specific-id</code> value MUST be able to be generated without the use
+of a centralized registry service. The <code>method-specific-id</code> value SHOULD
 be globally unique by itself. The fully qualified DID as defined by
 the DID rule in Section <a href="#generic-did-syntax"></a> MUST
 be globally unique.
@@ -2181,8 +2181,8 @@ be globally unique.
 
       <p>
 If needed, a specific DID scheme MAY define multiple specific
-specific-idstring formats. It is RECOMMENDED that a specific DID
-scheme define as few specific-idstring formats as possible.
+<code>method-specific-id</code> formats. It is RECOMMENDED that a specific DID
+scheme define as few <code>method-specific-id</code> formats as possible.
       </p>
     </section>
 

--- a/index.html
+++ b/index.html
@@ -971,12 +971,12 @@ illustrates both:
 
     <section>
       <h2>
-Paths
+Path
       </h2>
 
       <p>
-A generic <a>DID path</a> (the did-path rule in Section <a href="#the-generic-did-scheme"></a>) is identical to a URI path and MUST
-conform to the ABNF of the path-rootless ABNF rule in [[RFC3986]]. A
+A generic <a>DID path</a> is identical to a URI path and MUST
+conform to the the <code>path-abempty</code> ABNF rule in [[RFC3986]]. A
 DID path SHOULD be used to address resources available via a DID
 service endpoint. See Section <a href="#service-endpoints"></a>.
       </p>
@@ -989,13 +989,12 @@ more restrictive than the generic rules in this section.
 
     <section>
       <h2>
-Fragments
+Fragment
       </h2>
 
       <p>
-A generic <a>DID fragment</a> (the did-fragment rule in Section
-<a href="#the-generic-did-scheme"></a>) is identical to a URI
-fragment and MUST conform to the ABNF of the fragment ABNF rule in
+A generic <a>DID fragment</a> is identical to a URI
+fragment and MUST conform to the the <code>fragment</code> ABNF rule in
 [[RFC3986]]. A DID fragment MUST be used only as a method-independent
 reference into the DID Document to identify a component of a DID Document
 (e.g. a unique key description). To resolve this reference, the complete

--- a/index.html
+++ b/index.html
@@ -739,11 +739,17 @@ Generic DID Syntax
       <p>
 The generic <a>DID scheme</a> is a URI scheme conformant with
 [[RFC3986]]. The DID scheme specializes only the scheme and
-authority components of a DID URI—the path-abempty, query,
-and fragment components are identical to the ABNF rules defined
-in [[RFC3986]]. Note that the term “DID” refers only to the URI
-conforming to the did rule in the ABNF below. A DID always identifies
-the DID subject. The term “DID URL”, defined by the did-url rule,
+authority components of a DID URI—the <code>path-abempty</code>,
+<code>query</code>, and <code>fragment</code> components are
+identical to the ABNF rules defined
+in [[RFC3986]].
+      </p>
+
+      <p>
+The term <a>DID</a> refers only to the URI
+conforming to the <code>did</code> rule in the ABNF below. A
+DID always identifies the DID subject. The term <a>DID URL</a>,
+defined by the <code>did-url</code> rule,
 refers to a URL that begins with a DID followed by one or more
 additional components. A DID URL always identifies the resource to
 be located.
@@ -790,12 +796,11 @@ Generic DID Parameter Names
 
       <p>
 DID URL syntax supports a simple, generalized format for parameters based on the
-matrix parameter syntax ([[MatrixURIs]]) originally proposed in 1996 by Tim
-Berners-Lee and his collaborators. 
+matrix parameter syntax ([[MatrixURIs]]).
 The ABNF above does not specify any parameter names (the <code>param-name</code>
 rule). The following table defines a set of generic DID parameter names for
 parameters that MUST operate uniformly across all DID methods. (Method-specific
-parameter names are covered in the following section.)
+parameter names are covered in <a href="#method-specific-did-parameter-names"></a>.)
       </p>
 
       <table class="simple">
@@ -905,7 +910,7 @@ The exact processing rules for these parameters are specified in the DID
 Resolution specification.
       </p>
 
-      <p>
+      <p class="note">
 Note that there may be additional parameters or options that are not part
 of the DID URL but instead passed to a DID resolver “out of band”, i.e.,
 using a resolution protocol or some other mechanism. Such options could
@@ -940,7 +945,7 @@ this method and this method-specific parameter would be:
       </p>
 
       <p>
-Note that a method-specific parameter name defined by one DID method MAY
+A method-specific parameter name defined by one DID method MAY
 be used by other DID methods. For example:
       </p>
 
@@ -958,7 +963,7 @@ names in any order.
       </p>
 
       <p>
-Note that both DID method namespaces and method-specific parameter
+Both DID method namespaces and method-specific parameter
 namespaces may include colons, so they may be partitioned hierarchically
 as defined by a DID method specification. Here is an example DID URL that
 illustrates both:

--- a/index.html
+++ b/index.html
@@ -1021,7 +1021,7 @@ fragment and MUST conform to the the <code>fragment</code> ABNF rule in
 [[RFC3986]]. A DID fragment MUST be used only as a method-independent
 reference into the DID Document to identify a component of a DID Document
 (e.g. a unique key description). To resolve this reference, the complete
-DID reference including the DID fragment MUST be used as the value of
+DID URL including the DID fragment MUST be used as the value of
 the key for the target component in the DID Document object.
       </p>
 

--- a/index.html
+++ b/index.html
@@ -796,7 +796,7 @@ Generic DID Parameter Names
 
       <p>
 DID URL syntax supports a simple, generalized format for parameters based on the
-matrix parameter syntax ([[MatrixURIs]]).
+matrix parameter syntax ([[MATRIX-URIS]]).
 The ABNF above does not specify any parameter names (the <code>param-name</code>
 rule). The following table defines a set of generic DID parameter names for
 parameters that MUST operate uniformly across all DID methods. (Method-specific
@@ -898,7 +898,7 @@ may not be supported by all DID methods.
             </td>
             <td>
 A resource hash of the resource identified by the DID URL to add integrity
-protection, as specified in [[Hashlink]].
+protection, as specified in [[DRAFT-SPORNY-HASHLINK-02]].
             </td>
           </tr>
 

--- a/index.html
+++ b/index.html
@@ -745,7 +745,7 @@ identical to the ABNF rules defined
 in [[RFC3986]].
       </p>
 
-      <p>
+      <p class="note">
 The term <a>DID</a> refers only to the URI
 conforming to the <code>did</code> rule in the ABNF below. A
 DID always identifies the DID subject. The term <a>DID URL</a>,

--- a/index.html
+++ b/index.html
@@ -798,114 +798,114 @@ parameters that MUST operate uniformly across all DID methods. (Method-specific
 parameter names are covered in the following section.)
       </p>
 
-        <table class="simple">
-          <thead>
-            <tr>
-              <th>Parameter Name</th>
-              <th>Description</th>
-            </tr>
-          </thead>
+      <table class="simple">
+        <thead>
+          <tr>
+            <th>Parameter Name</th>
+            <th>Description</th>
+          </tr>
+        </thead>
 
-          <tbody>
-            <tr>
-              <td>
+        <tbody>
+          <tr>
+            <td>
 <code>service</code>
-              </td>
-              <td>
+            </td>
+            <td>
 Selects a <code>service</code> JSON-LD object from the DID Document by id.
-              </td>
-            </tr>
+            </td>
+          </tr>
 
-            <tr>
-              <td>
+          <tr>
+            <td>
 <code>service-type</code>
-              </td>
-              <td>
+            </td>
+            <td>
 Selects all <code>service</code> JSON-LD objects from the DID Document by type.
-              </td>
-            </tr>
+            </td>
+          </tr>
 
-            <tr>
-              <td>
+          <tr>
+            <td>
 <code>key</code>
-              </td>
-              <td>
+            </td>
+            <td>
 Selects a <code>publicKey</code> JSON-LD object from the DID Document by id.
-              </td>
-            </tr>
+            </td>
+          </tr>
 
-            <tr>
-              <td>
+          <tr>
+            <td>
 <code>key-type</code>
-              </td>
-              <td>
+            </td>
+            <td>
 Selects all <code>publicKey</code> JSON-LD objects from the DID Document by type.
-              </td>
-            </tr>
+            </td>
+          </tr>
 
-            <tr>
-              <td>
+          <tr>
+            <td>
 <code>version-id</code>
-              </td>
-              <td>
+            </td>
+            <td>
 Specifies a specific version of a DID Document to be resolved (the version ID
 could be sequential, or a UUID, or method-specific). Note: This parameter may
 not be supported by all DID methods.
-              </td>
-            </tr>
+            </td>
+          </tr>
 
-            <tr>
-              <td>
+          <tr>
+            <td>
 <code>version-time</code>
-              </td>
-              <td>
+            </td>
+            <td>
 Specifies a certain version timestamp of a DID Document to be resolved (i.e.
 the DID Document that was valid for a DID at a certain time). Note: This
 parameter may not be supported by all DID methods.
-              </td>
-            </tr>
+            </td>
+          </tr>
 
-            <tr>
-              <td>
+          <tr>
+            <td>
 <code>content-type</code>
-              </td>
-              <td>
+            </td>
+            <td>
 Specifies a type of content object (other than a DID Document) to be returned
 from the target DID registry. Note: This parameter may not be supported by
 all DID methods.
-              </td>
-            </tr>
+            </td>
+          </tr>
 
-            <tr>
-              <td>
+          <tr>
+            <td>
 <code>content-id</code>
-              </td>
-              <td>
+            </td>
+            <td>
 Specifies the method-specific identifier of a content object (other than a DID
 Document) to be returned from the target DID registry. Note: This parameter
 may not be supported by all DID methods.
-              </td>
-            </tr>
+            </td>
+          </tr>
 
-            <tr>
-              <td>
+          <tr>
+            <td>
 <code>hl</code>
-              </td>
-              <td>
+            </td>
+            <td>
 A resource hash of the resource identified by the DID URL to add integrity
 protection, as specified in [[Hashlink]].
-              </td>
-            </tr>
+            </td>
+          </tr>
 
-          </tbody>
-        </table>
-        
-        <p>
+        </tbody>
+      </table>
+
+      <p>
 The exact processing rules for these parameters are specified in the DID
 Resolution specification.
-        </p>
+      </p>
 
-        <p>
+      <p>
 Note that there may be additional parameters or options that are not part
 of the DID URL but instead passed to a DID resolver “out of band”, i.e.,
 using a resolution protocol or some other mechanism. Such options could
@@ -915,7 +915,7 @@ HTTP headers rather than as part of an HTTP URL. The important distinction
 is that DID parameters that are part of the DID URL specify what resource
 is being identified, whereas DID resolver options that are not part of the
 DID URL control how that resource is dereferenced.
-        </p>
+      </p>
     </section>
 
     <section>

--- a/index.html
+++ b/index.html
@@ -798,15 +798,28 @@ Generic DID Parameter Names
 DID URL syntax supports a simple, generalized format for parameters based on the
 matrix parameter syntax ([[MATRIX-URIS]]).
 The ABNF above does not specify any parameter names (the <code>param-name</code>
-rule). The following table defines a set of generic DID parameter names for
-parameters that MUST operate uniformly across all DID methods. (Method-specific
-parameter names are covered in <a href="#method-specific-did-parameter-names"></a>.)
+rule).
+      </p>
+      <p>
+Some generic DID parameter names (e.g. for service selection) are completely
+independent of any specific DID method and MUST always function the same way
+for all DIDs.
+Others (e.g. for versioning) MAY be supported by
+certain DID methods, but MUST operate uniformly across those DID methods that
+do support them.
+      </p>
+      <p>
+Parameter names that are completely method-specific are covered in
+<a href="#method-specific-did-parameter-names"></a>.
+      </p>
+      <p>
+The following table defines a set of generic DID parameter names:
       </p>
 
       <table class="simple">
         <thead>
           <tr>
-            <th>Parameter Name</th>
+            <th>Generic DID Parameter Name</th>
             <th>Description</th>
           </tr>
         </thead>

--- a/index.html
+++ b/index.html
@@ -1062,7 +1062,7 @@ The method name MUST be lowercase.
 
         <li>
 Case sensitivity and normalization of the value of the
-specific-idstring rule in Section <a href="#the-generic-did-scheme">
+specific-idstring rule in Section <a href="#generic-did-syntax">
           </a> MUST be defined by the governing DID method specification.
         </li>
       </ol>
@@ -2147,8 +2147,8 @@ DID Method Schemes
 
       <p>
 A DID method specification MUST define exactly one specific DID
-scheme identified by exactly one method name (the method rule in
-Section <a href="#the-generic-did-scheme"></a>).
+scheme identified by exactly one method name (the <code>method-name</code> rule in
+Section <a href="#generic-did-syntax"></a>).
       </p>
 
       <p>
@@ -2175,7 +2175,7 @@ how to generate the specific-idstring component of a DID. The
 specific-idstring value MUST be able to be generated without the use
 of a centralized registry service. The specific-idstring value SHOULD
 be globally unique by itself. The fully qualified DID as defined by
-the DID rule in Section <a href="#the-generic-did-scheme"></a> MUST
+the DID rule in Section <a href="#generic-did-syntax"></a> MUST
 be globally unique.
       </p>
 

--- a/index.html
+++ b/index.html
@@ -733,35 +733,239 @@ enables authentication of the DID subject.
 
     <section>
       <h2>
-The Generic DID Scheme
+Generic DID Syntax
       </h2>
 
       <p>
 The generic <a>DID scheme</a> is a URI scheme conformant with
-[[RFC3986]]. It consists of a DID followed by an optional path and/or
-fragment. The term DID refers only to the identifier conforming to
-the did rule in the ABNF below; when used alone, it does not include
-a path or fragment. A DID that may optionally include a path and/or
-fragment is called a DID reference.
+[[RFC3986]]. The DID scheme specializes only the scheme and
+authority components of a DID URI—the path-abempty, query,
+and fragment components are identical to the ABNF rules defined
+in [[RFC3986]]. Note that the term “DID” refers only to the URI
+conforming to the did rule in the ABNF below. A DID always identifies
+the DID subject. The term “DID URL”, defined by the did-url rule,
+refers to a URL that begins with a DID followed by one or more
+additional components. A DID URL always identifies the resource to
+be located.
       </p>
 
       <p>
-Following is the ABNF definition using the syntax in [[RFC5234]]
-        (which defines ALPHA as upper or lowercase A-Z).
+The following is the ABNF definition using the syntax in [[RFC5234]]
+which defines ALPHA and DIGIT. All other rule names not defined in
+this ABNF are defined in [[RFC3986]].
       </p>
 
       <pre class="nohighlight">
-did-reference      = did [ "/" did-path ] [ "#" did-fragment ]
-did                = "did:" method ":" specific-idstring
-method             = 1*methodchar
-methodchar         = %x61-7A / DIGIT
-specific-idstring  = idstring *( ":" idstring )
-idstring           = 1*idchar
-idchar             = ALPHA / DIGIT / "." / "-"
+did                = "did:" method-name ":" method-specific-id
+method-name        = 1*method-char
+method-char        = %x61-7A / DIGIT
+method-specific-id = *idchar *( ":" *idchar )
+idchar             = ALPHA / DIGIT / "." / "-" / "_"
+did-url            = did *( ";" param ) path-abempty [ "?" query ] 
+                     [ "#" fragment ]
+param              = param-name [ "=" param-value ]
+param-name         = 1*param-char
+param-value        = *param-char
+param-char         = ALPHA / DIGIT / "." / "-" / "_" / ":" /
+                     pct-encoded
 </pre>
+    </section>
+
+    <section>
+      <h2>
+Method-Specific Syntax
+      </h2>
+
       <p>
-See Sections <a href="#paths"></a> and <a href="#fragments"></a> for the ABNF rules defining DID paths and
-fragments.
+A DID method specification MUST further restrict the generic DID
+syntax by defining its own <code>method-name</code> and its own
+<code>method-specific-id</code> syntax. See Section <a href="#did-methods"></a>.
+      </p>
+    </section>
+
+    <section>
+      <h2>
+Generic DID Parameter Names
+      </h2>
+
+      <p>
+DID URL syntax supports a simple, generalized format for parameters based on the
+matrix parameter syntax ([[MatrixURIs]]) originally proposed in 1996 by Tim
+Berners-Lee and his collaborators. 
+The ABNF above does not specify any parameter names (the <code>param-name</code>
+rule). The following table defines a set of generic DID parameter names for
+parameters that MUST operate uniformly across all DID methods. (Method-specific
+parameter names are covered in the following section.)
+      </p>
+
+        <table class="simple">
+          <thead>
+            <tr>
+              <th>Parameter Name</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+
+          <tbody>
+            <tr>
+              <td>
+<code>service</code>
+              </td>
+              <td>
+Selects a <code>service</code> JSON-LD object from the DID Document by id.
+              </td>
+            </tr>
+
+            <tr>
+              <td>
+<code>service-type</code>
+              </td>
+              <td>
+Selects all <code>service</code> JSON-LD objects from the DID Document by type.
+              </td>
+            </tr>
+
+            <tr>
+              <td>
+<code>key</code>
+              </td>
+              <td>
+Selects a <code>publicKey</code> JSON-LD object from the DID Document by id.
+              </td>
+            </tr>
+
+            <tr>
+              <td>
+<code>key-type</code>
+              </td>
+              <td>
+Selects all <code>publicKey</code> JSON-LD objects from the DID Document by type.
+              </td>
+            </tr>
+
+            <tr>
+              <td>
+<code>version-id</code>
+              </td>
+              <td>
+Specifies a specific version of a DID Document to be resolved (the version ID
+could be sequential, or a UUID, or method-specific). Note: This parameter may
+not be supported by all DID methods.
+              </td>
+            </tr>
+
+            <tr>
+              <td>
+<code>version-time</code>
+              </td>
+              <td>
+Specifies a certain version timestamp of a DID Document to be resolved (i.e.
+the DID Document that was valid for a DID at a certain time). Note: This
+parameter may not be supported by all DID methods.
+              </td>
+            </tr>
+
+            <tr>
+              <td>
+<code>content-type</code>
+              </td>
+              <td>
+Specifies a type of content object (other than a DID Document) to be returned
+from the target DID registry. Note: This parameter may not be supported by
+all DID methods.
+              </td>
+            </tr>
+
+            <tr>
+              <td>
+<code>content-id</code>
+              </td>
+              <td>
+Specifies the method-specific identifier of a content object (other than a DID
+Document) to be returned from the target DID registry. Note: This parameter
+may not be supported by all DID methods.
+              </td>
+            </tr>
+
+            <tr>
+              <td>
+<code>hl</code>
+              </td>
+              <td>
+A resource hash of the resource identified by the DID URL to add integrity
+protection, as specified in [[Hashlink]].
+              </td>
+            </tr>
+
+          </tbody>
+        </table>
+        
+        <p>
+The exact processing rules for these parameters are specified in the DID
+Resolution specification.
+        </p>
+
+        <p>
+Note that there may be additional parameters or options that are not part
+of the DID URL but instead passed to a DID resolver “out of band”, i.e.,
+using a resolution protocol or some other mechanism. Such options could
+for example control caching or the desired format of a resolution result.
+This is similar to HTTP, where caching or result format are expressed as
+HTTP headers rather than as part of an HTTP URL. The important distinction
+is that DID parameters that are part of the DID URL specify what resource
+is being identified, whereas DID resolver options that are not part of the
+DID URL control how that resource is dereferenced.
+        </p>
+    </section>
+
+    <section>
+      <h2>
+Method-Specific DID Parameter Names
+      </h2>
+
+      <p>
+A DID method specification MAY specify additional method-specific parameter
+names. A method-specific parameter name MUST be prefixed by the method name
+as defined by the <code>method-name</code> rule.
+      </p>
+
+      <p>
+For example, if the method <code>did:foo:</code> defines the parameter bar,
+the parameter name must be <code>foo:bar</code>. An example DID URL using
+this method and this method-specific parameter would be:
+      </p>
+
+      <p>
+<code>did:foo:21tDAKCERh95uGgKbJNHYp;foo:bar=high</code>
+      </p>
+
+      <p>
+Note that a method-specific parameter name defined by one DID method MAY
+be used by other DID methods. For example:
+      </p>
+
+      <p>
+<code>did:example:21tDAKCERh95uGgKbJNHYp;foo:bar=low</code>
+      </p>
+
+      <p>
+Method-specific parameter names MAY be combined with generic parameter
+names in any order.
+      </p>
+
+      <p>
+<code>did:example:21tDAKCERh95uGgKbJNHYp;service=agent;foo:bar=high</code>
+      </p>
+
+      <p>
+Note that both DID method namespaces and method-specific parameter
+namespaces may include colons, so they may be partitioned hierarchically
+as defined by a DID method specification. Here is an example DID URL that
+illustrates both:
+      </p>
+
+      <p>
+<code>did:foo:baz:21tDAKCERh95uGgKbJNHYp;foo:baz:hex=b612</code>
       </p>
     </section>
 

--- a/index.html
+++ b/index.html
@@ -989,6 +989,24 @@ more restrictive than the generic rules in this section.
 
     <section>
       <h2>
+Query
+      </h2>
+
+      <p>
+A generic <a>DID query</a> is identical to a URI query and MUST
+conform to the the <code>query</code> ABNF rule in [[RFC3986]]. A
+DID query SHOULD be used to address resources available via a DID
+service endpoint. See Section <a href="#service-endpoints"></a>.
+      </p>
+
+      <p>
+A specific DID scheme MAY specify ABNF rules for DID queries that are
+more restrictive than the generic rules in this section.
+      </p>
+    </section>
+
+    <section>
+      <h2>
 Fragment
       </h2>
 

--- a/terms.html
+++ b/terms.html
@@ -80,11 +80,9 @@ compatible graph-based data formats.
   <dt><dfn data-lt="">DID Fragment</dfn></dt>
 
   <dd>
-The portion of a <a>DID reference</a> that follows the first hash
+The portion of a <a>DID URL</a> that follows the first hash
 sign character ("#"). A DID fragment uses the same syntax as a URI
-fragment. See section 5.5. Note that a DID fragment MUST immediately
-follow a DID. If a DID reference includes a DID path followed by a
-fragment, that fragment is NOT a DID fragment.
+fragment. See section 5.7.
   </dd>
 
 
@@ -103,18 +101,27 @@ are written and updated.
   <dt><dfn data-lt="">DID Path</dfn></dt>
 
   <dd>
-The portion of a <a>DID reference</a> that follows the first forward
-slash character. A DID path uses the identical syntax as a URI path. See
-section 5.4. Note that if a DID path is followed by a fragment, that
-fragment is NOT a <a>DID fragment</a>.
+The portion of a <a>DID URL</a> that follows the first forward
+slash character ("/"). A DID path uses the identical syntax as a URI path.
+See section 5.5.
   </dd>
 
 
 
-  <dt><dfn data-lt="">DID Reference</dfn></dt>
+  <dt><dfn data-lt="">DID Query</dfn></dt>
 
   <dd>
-A DID plus an optional <a>DID path</a> or <a>DID fragment</a>.
+The portion of a <a>DID URL</a> that follows the first question
+mark character ("?"). A DID path uses the identical syntax as a URI path.
+See section 5.6.
+  </dd>
+
+
+
+  <dt><dfn data-lt="">DID URL</dfn></dt>
+
+  <dd>
+A DID plus an optional <a>DID path</a>, optional <a>DID query</a>, and optional <a>DID fragment</a>.
   </dd>
 
 


### PR DESCRIPTION
This updates the ABNF and introduces matrix parameters, based on discussions on the mailing list as well as the [DID Spec and DID Resolution Spec Weekly Meetings](https://docs.google.com/document/d/1qYBaXQMUoB86Alquu7WBtWOxsS8SMhp1fioYKEGCabE/).

Fixes #85. Fixes #90. Fixes #170. Fixes #177.
Replaces https://github.com/w3c-ccg/did-spec/pull/106.
Related to #185.

**[PR is still work-in-progress, do not merge yet!]**


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/did-spec/pull/187.html" title="Last updated on Apr 26, 2019, 4:57 PM UTC (9ec0477)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/did-spec/187/ce1130d...9ec0477.html" title="Last updated on Apr 26, 2019, 4:57 PM UTC (9ec0477)">Diff</a>