### PR TITLE
Add "service" DID URL matrix parameter.

### DIFF
--- a/index.html
+++ b/index.html
@@ -764,6 +764,15 @@ The following table defines a set of generic DID parameter names:
         </thead>
 
         <tbody>
+          <tr>
+            <td>
+<code>service</code>
+            </td>
+            <td>
+Identifies a service from the DID Document by service id.
+            </td>
+          </tr>
+
         </tbody>
       </table>
 


### PR DESCRIPTION
This adds one concrete DID URL matrix parameter. See https://github.com/w3c-ccg/did-spec/pull/189.

Description: Identifies a service from the DID Document by service id.

Example: `did:example:1234;service=myhub`


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/did-spec/pull/190.html" title="Last updated on May 10, 2019, 11:38 AM UTC (ddec242)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/did-spec/190/fde9370...ddec242.html" title="Last updated on May 10, 2019, 11:38 AM UTC (ddec242)">Diff</a>