### PR TITLE
Add "service-type" DID URL matrix parameter.

### DIFF
--- a/index.html
+++ b/index.html
@@ -764,6 +764,15 @@ The following table defines a set of generic DID parameter names:
         </thead>
 
         <tbody>
+          <tr>
+            <td>
+<code>service-type</code>
+            </td>
+            <td>
+Identifies a set of services from the DID Document by service type.
+            </td>
+          </tr>
+
         </tbody>
       </table>
 


### PR DESCRIPTION
This adds one concrete DID URL matrix parameter. See https://github.com/w3c-ccg/did-spec/pull/189.

Description: Identifies a set of services from the DID Document by service type.

Example: `did:example:1234;service-type=agent`


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/did-spec/pull/191.html" title="Last updated on May 10, 2019, 11:40 AM UTC (4a792ab)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/did-spec/191/fde9370...4a792ab.html" title="Last updated on May 10, 2019, 11:40 AM UTC (4a792ab)">Diff</a>