### PR TITLE
Add "key-type" DID URL matrix parameter.

### DIFF
--- a/index.html
+++ b/index.html
@@ -764,6 +764,15 @@ The following table defines a set of generic DID parameter names:
         </thead>
 
         <tbody>
+          <tr>
+            <td>
+<code>key-type</code>
+            </td>
+            <td>
+Identifies a set of keys from the DID Document by key type.
+            </td>
+          </tr>
+
         </tbody>
       </table>
 


### PR DESCRIPTION
This adds one concrete DID URL matrix parameter. See https://github.com/w3c-ccg/did-spec/pull/189.

Description: Identifies a set of keys from the DID Document by key type.

Example: `did:example:1234;key-type=Ed25519VerificationKey2018`


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/did-spec/pull/193.html" title="Last updated on May 10, 2019, 11:41 AM UTC (e7c1c4a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/did-spec/193/fde9370...e7c1c4a.html" title="Last updated on May 10, 2019, 11:41 AM UTC (e7c1c4a)">Diff</a>