### PR TITLE
Add "content-type" and "content-id" DID URL matrix parameters.

### DIFF
--- a/index.html
+++ b/index.html
@@ -764,6 +764,28 @@ The following table defines a set of generic DID parameter names:
         </thead>
 
         <tbody>
+          <tr>
+            <td>
+<code>content-type</code>
+            </td>
+            <td>
+Specifies a type of content object (other than a DID Document) to be returned
+from the target DID registry. Note: This parameter may not be supported by
+all DID methods.
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+<code>content-id</code>
+            </td>
+            <td>
+Specifies the method-specific identifier of a content object (other than a DID
+Document) to be returned from the target DID registry. Note: This parameter
+may not be supported by all DID methods.
+            </td>
+          </tr>
+
         </tbody>
       </table>
 


### PR DESCRIPTION
This adds two concrete DID URL matrix parameters. See https://github.com/w3c-ccg/did-spec/pull/189.

Description: At Rebooting-the-Web-of-Trust 8 in Barcelona, a use case was described by @talltree and @kenebert to use DID URL syntax for referencing objects in a DID target system that are not DID Documents. See https://github.com/WebOfTrustInfo/rwot8-barcelona/blob/master/topics-and-advance-readings/DID-Content-References.md.

Example: `did:example:1234;content-type=schema;content-id=z9y8x7w6`


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/did-spec/pull/195.html" title="Last updated on May 10, 2019, 11:44 AM UTC (818dfe4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/did-spec/195/fde9370...818dfe4.html" title="Last updated on May 10, 2019, 11:44 AM UTC (818dfe4)">Diff</a>