### PR TITLE
Fix #201 and #56 -- Added support for public keys as Ethereum addresses 

### DIFF
--- a/index.html
+++ b/index.html
@@ -1234,7 +1234,9 @@ A DID Document MAY include a <code>publicKey</code> property.
 
         <li>
 The value of the <code>publicKey</code> property MUST be an array of
-public keys.
+public keys, and every public key property MUST be in the
+<a href="https://w3c-ccg.github.io/ld-cryptosuite-registry">Linked Data
+Cryptographic Suite Registry</a>.
         </li>
 
         <li>

--- a/index.html
+++ b/index.html
@@ -1255,8 +1255,8 @@ A registry of key types and formats is available in Appendix
         </li>
       </ol>
       <p class="note">
-        The following is a non-exhaustive list of public keys
-        used by the community:
+        The following is a non-exhaustive list of public key
+        properties used by the community:
         <code>publicKeyPem</code>, <code>publicKeyJwk</code>,
         <code>publicKeyHex</code>, <code>publicKeyBase64</code>,
         <code>publicKeyBase58</code>, <code>publicKeyMultibase</code>,


### PR DESCRIPTION
This PR addresses the immediate need to support public keys as Ethereum addresses and removes constraints on public keys in general. This will ensure that any entry in the referenced registry (once final) can be used to describe the key types and formats.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/uport-project/did-spec/pull/202.html" title="Last updated on Jun 6, 2019, 6:35 PM UTC (3786800)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/did-spec/202/fde9370...uport-project:3786800.html" title="Last updated on Jun 6, 2019, 6:35 PM UTC (3786800)">Diff</a>