### PR TITLE
Added 'id' attribute of the 'service' definition for DID doc example

### DIFF
--- a/index.html
+++ b/index.html
@@ -318,6 +318,7 @@ interact with the entity.
   }],
   "service": [{
     <span class="comment">// used to retrieve Verifiable Credentials associated with the DID</span>
+    "id":"did:example:123456789abcdefghi#vcs",
     "type": "VerifiableCredentialService",
     "serviceEndpoint": "https://example.com/vc/"
   }]


### PR DESCRIPTION
According to later in the spec, attribute 'id' is a required field of a 'service' definition.

Have come across uPort docs that do not specify **authentication** and **'service'**s with the **id** attributes and perhaps this incomplete example may mislead devs.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/DibbsZA/did-spec/pull/206.html" title="Last updated on Jun 3, 2019, 8:11 AM UTC (9bb2c77)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/did-spec/206/e268a4e...DibbsZA:9bb2c77.html" title="Last updated on Jun 3, 2019, 8:11 AM UTC (9bb2c77)">Diff</a>