### PR TITLE
Add link to spec for discovering DIDs from DNS.

### DIFF
--- a/common.js
+++ b/common.js
@@ -106,6 +106,17 @@ var ccg = {
         "Tim Berners-Lee"
       ],
       status: "Personal View"
+    },
+    "DNS-DID": {
+      title: "The Decentralized Identifier (DID) in the DNS",
+      date: "February 2019",
+      href: "https://datatracker.ietf.org/doc/draft-mayrhofer-did-dns/",
+      authors: [
+        "Alexander Mayrhofer",
+        "Dimitrij Klesev",
+        "Markus Sabadello"
+      ],
+      status: "Internet-Draft"
     }
   }
 };

--- a/index.html
+++ b/index.html
@@ -2470,6 +2470,11 @@ the true human-friendly identifier for a target entity, and (b) the
 privacy consequences of using human-friendly identifiers that are
 inherently correlatable, especially if they are globally unique.
       </p>
+
+      <p class="note">
+A draft specification for discovering a DID from domain names and
+e-mail addresses using DNS lookups is available at [[DNS-DID]].
+	  </p>
     </section>
 
   </section>


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/did-spec/pull/208.html" title="Last updated on Jun 3, 2019, 1:20 PM UTC (1a3c05b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/did-spec/208/e268a4e...1a3c05b.html" title="Last updated on Jun 3, 2019, 1:20 PM UTC (1a3c05b)">Diff</a>