### PR TITLE
Fix delegates section link.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1584,7 +1584,7 @@ The subject as defined in section <a href="#service-endpoints"></a>, or if not p
         </li>
 
         <li>
-The delegate as defined in section 4.3.
+The delegate as defined in Section <a href="#delegates"></a>.
         </li>
       </ol>
 


### PR DESCRIPTION
Unsure how to handle this.  The section number listed is old and incorrect.  But also the entire delegates section is currently commented out.  If this `<li>` here is also commented out then there is no need for a list so the surrounding text should be reworked.  This issue may just be a reminder for someone to revisit and fix this text later.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/digitalbazaar/did-spec/pull/237.html" title="Last updated on Jul 9, 2019, 10:38 PM UTC (69eaadc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/did-spec/237/ddea01a...digitalbazaar:69eaadc.html" title="Last updated on Jul 9, 2019, 10:38 PM UTC (69eaadc)">Diff</a>