### PR TITLE
moved list from charter to spec

### DIFF
--- a/index.html
+++ b/index.html
@@ -283,7 +283,32 @@ addition to defining a specific DID scheme, must also specify the
 methods for resolving and deactivating DIDs and writing DID documents on the
 network for which it is written.
       </p>
-
+      <p>
+The hierarchical design of a generic DID specification with specific DID method
+specifications introduces some of the same concepts as the URI specification:
+      </p>
+        <ul>
+          <li>
+DIDs from different DID methods may not be interoperable, just as URIs from
+different URI schemes may not be interoperable.
+          </li>
+          <li>
+Entities may need multiple DIDs to support different relationships, as the other
+party may only support certain DID methods, just as some browsers may only
+support certain URI schemes.
+          </li>
+          <li>
+Entities may need multiple DIDs to support the different cryptographic schemes
+of different DID methods, as not all parties will support the same cryptographic
+schemes, just as not all browsers support the same URI schemes.
+          </li>
+          <li>
+Managing multiple DIDs, and tracking which DID belongs to which relationship,
+under which cryptographic scheme, introduces similar logistical challenges as
+managing multiple web addresses and tracking which address belongs to which
+website, or tracking which email address belongs to which relationship.
+          </li>
+        </ul>
       <p>
 For a list of DID Methods and their corresponding specifications,
 see the DID Method Registry [[DID-METHOD-REGISTRY]].


### PR DESCRIPTION
This PR moves proposed text from the [DID WG charter ](https://github.com/w3c-ccg/did-wg-charter/pull/41) to the DID specification.
Signed-off-by: Brent <brent.zundel@gmail.com>


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/brentzundel/did-spec/pull/239.html" title="Last updated on Jul 15, 2019, 7:39 PM UTC (f11a38d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/did-spec/239/f3c7dae...brentzundel:f11a38d.html" title="Last updated on Jul 15, 2019, 7:39 PM UTC (f11a38d)">Diff</a>