### PR TITLE
Add correct Identity Hub ServiceEndpoint format

### DIFF
--- a/index.html
+++ b/index.html
@@ -1496,8 +1496,13 @@ Example:
     "serviceEndpoint": "https://agent.example.com/8377464"
   }, {
     "id": "did:example:123456789abcdefghi#hub",
-    "type": "HubService",
-    "serviceEndpoint": "https://hub.example.com/.identity/did:example:0123456789abcdef/"
+    "type": "IdentityHub",
+    "publicKey": "did:example:123456789abcdefghi#key-1",
+    "serviceEndpoint": {
+      "@context": "https://schema.identity.foundation/hub",
+      "type": "UserHubEndpoint",
+      "instances": ["did:example:456", "did:example:789"]
+    }
   }, {
     "id": "did:example:123456789abcdefghi#messages",
     "type": "MessagingService",


### PR DESCRIPTION
Fixes typo in https://github.com/w3c-ccg/did-spec/pull/230


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/did-spec/pull/245.html" title="Last updated on Aug 2, 2019, 6:35 PM UTC (a64df96)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/did-spec/245/9dc12be...a64df96.html" title="Last updated on Aug 2, 2019, 6:35 PM UTC (a64df96)">Diff</a>