### PR TITLE
Replace draft context URI with w3.org one in all examples

### DIFF
--- a/index.html
+++ b/index.html
@@ -338,7 +338,7 @@ interact with the entity.
 
     <pre class="example nohighlight" title="Minimal self-managed DID Document">
 {
-  "@context": "https://w3id.org/did/v1",
+  "@context": "https://www.w3.org/2019/did/v1",
   "id": "did:example:123456789abcdefghi",
   "authentication": [{
     <span class="comment">// used to authenticate as did:...fghi</span>
@@ -993,7 +993,7 @@ Example (using an example URL):
 
       <pre class="example nohighlight">
 {
-  "@context": "https://w3id.org/did/v1"
+  "@context": "https://www.w3.org/2019/did/v1"
 }
 </pre>
       <p>
@@ -1123,7 +1123,7 @@ Example:
 
 <pre class="example nohighlight" title="Basic DID Document">
 {
-"@context": "https://w3id.org/did/v1",
+"@context": "https://www.w3.org/2019/did/v1",
 "id": "did:example:123456789abcdefghi",
 "authorizationCapability": [{
   // this entity is a delegate and may update any field in this
@@ -1217,7 +1217,7 @@ Example:
 
       <pre class="example nohighlight" title="Various public keys">
 {
-  "@context": ["https://w3id.org/did/v1", "https://w3id.org/security/v1"],
+  "@context": ["https://www.w3.org/2019/did/v1", "https://w3id.org/security/v1"],
   "id": "did:example:123456789abcdefghi",
   ...
   "publicKey": [{
@@ -1373,7 +1373,7 @@ Example:
 
       <pre class="example nohighlight" title="Authentication field containing three verification methods">
 {
-  "@context": "https://w3id.org/did/v1",
+  "@context": "https://www.w3.org/2019/did/v1",
   "id": "did:example:123456789abcdefghi",
   ...
   "authentication": [
@@ -1445,7 +1445,7 @@ Example:
 
       <pre class="example nohighlight" title="DID Document with a controller property">
 {
-  "@context": "https://w3id.org/did/v1",
+  "@context": "https://www.w3.org/2019/did/v1",
   "id": "did:example:123456789abcdefghi",
   "controller": "did:example:bcehfew7h32f32h7af3",
   "service": [{


### PR DESCRIPTION
Changes examples only, fixes #241


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/did-spec/pull/246.html" title="Last updated on Aug 2, 2019, 6:50 PM UTC (543deed)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/did-spec/246/957ef13...543deed.html" title="Last updated on Aug 2, 2019, 6:50 PM UTC (543deed)">Diff</a>