### PR TITLE
Another RFC2119 capitalization fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -1483,7 +1483,7 @@ of service endpoints.
         </li>
 
         <li>
-Each service endpoint must include <code>id</code>,
+Each service endpoint MUST include <code>id</code>,
         <code>type</code>, and <code>serviceEndpoint</code> properties, and
 MAY include additional properties.
         </li>


### PR DESCRIPTION
Similar to the ones that have been merged in https://github.com/w3c-ccg/did-spec/pull/209


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/did-spec/pull/248.html" title="Last updated on Aug 2, 2019, 9:46 PM UTC (ab9a1b6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/did-spec/248/957ef13...ab9a1b6.html" title="Last updated on Aug 2, 2019, 9:46 PM UTC (ab9a1b6)">Diff</a>