### PR TITLE
Fix inconsistent use of term 'DID subject'

### DIFF
--- a/index.html
+++ b/index.html
@@ -1333,14 +1333,14 @@ Authentication
       </h2>
 
       <p>
-Authentication is the mechanism by which a <a href="#did-subject">DID subject</a> can
-cryptographically prove that they are associated with a DID.
+Authentication is the mechanism by which the controller(s) of a DID can
+cryptographically prove that they are associated with that DID.
 See Section <a href="#binding-of-identity"></a>. Note
-that Authentication is separate from Authorization because the subject
+that Authentication is separate from Authorization because the controllers
 may wish to enable others to update their DID Document (for
 example, to assist with key recovery as discussed in Section
 <a href="#key-revocation-and-recovery"></a>) without enabling them to prove
-control (and thus be able to impersonate the subject).
+control (and thus be able to impersonate the controllers).
       </p>
 
       <p>


### PR DESCRIPTION
Signed-off-by: Daniel Hardman <daniel.hardman@gmail.com>


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dhh1128/did-spec/pull/255.html" title="Last updated on Aug 8, 2019, 9:38 AM UTC (8d99ae0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/did-spec/255/bd4f2fa...dhh1128:8d99ae0.html" title="Last updated on Aug 8, 2019, 9:38 AM UTC (8d99ae0)">Diff</a>