### PR TITLE
Add basic info to the data model section

### DIFF
--- a/index.html
+++ b/index.html
@@ -533,26 +533,65 @@ Terminology
 Data Model
     </h1>
     <p>
-This section outlines the Decentralized Identifier data model concepts.
-These are elaborated in <a href="#did-documents"></a>.
+This section outlines the Decentralized Identifier data model concepts,
+in particular how keys, services and the DID Subject are related to the
+DID Document.
+    </p>
+    <p>
+For information about how the data model can be extended, see
+<a href="#extensibility"></a>.
     </p>
 
     <section>
       <h2>
 Document
       </h2>
+      <p>
+A DID resolves to a DID Document. This is the concrete serialization of
+the data model, according to a particular syntax (see
+<a href="#did-document-syntax"></a>). The DID Document contains attributes
+or claims about the <a href="#did-subject"></a>, and the DID itself is
+contained in the <code>id</code> property.
+      </p>
+      <p>
+The properties that can be present in a DID Document are detailed
+further in <a href="#did-documents"></a>.
+      </p>
+      <p>
+The properties present in a DID Document can be updated according to
+the applicable <a href="#did-methods"></a>.
+      </p>
     </section>
 
     <section>
       <h2>
 Keys
       </h2>
+      <p>
+One or more <a href="#public-keys"></a> can be included in a DID
+Document using the <code>publicKey</code> or <code>authentication</code>
+properties depending on what they are to be used for. Each public key
+has an identifier (<code>id</code>) of its own, a <code>type</code>,
+and a <code>controller</code>, as well as other properties which
+depend on what type of key it is.
+      </p>
     </section>
 
     <section>
       <h2>
 Services
       </h2>
+      <p>
+A DID Document can contain pointers to services using the <code>
+service</code> property. Services can be anything the DID Subject
+wishes to advertise, for example other ways to interact with
+the DID Subject. Each service has its own <code>id</code> and
+<code>type</code>, as well as a <code>serviceEndpoint</code> with a
+URI or further properties describing the service.
+      </p>
+      <p>
+For more information see <a href="#service-endpoints"></a>.
+      </p>
     </section>
 
   </section>

--- a/index.html
+++ b/index.html
@@ -534,7 +534,7 @@ Data Model
     </h1>
     <p>
 This section outlines the Decentralized Identifier data model concepts,
-in particular how keys, services and the DID Subject are related to the
+in particular how keys, services, and the DID Subject are related to the
 DID Document.
     </p>
     <p>

--- a/index.html
+++ b/index.html
@@ -569,7 +569,7 @@ Keys
       </h2>
       <p>
 One or more <a href="#public-keys"></a> can be included in a DID
-Document using the <code>publicKey</code> or <code>authentication</code>
+Document using, for example, the <code>publicKey</code> or <code>authentication</code>
 properties depending on what they are to be used for. Each public key
 has an identifier (<code>id</code>) of its own, a <code>type</code>,
 and a <code>controller</code>, as well as other properties which

--- a/index.html
+++ b/index.html
@@ -534,8 +534,8 @@ Data Model
     </h1>
     <p>
 This section outlines the Decentralized Identifier data model concepts,
-in particular how keys, services, and the DID Subject are related to the
-DID Document.
+in particular how keys, services, and the <a>DID Subject</a> are related to the
+<a>DID Document</a>.
     </p>
     <p>
 For information about how the data model can be extended, see
@@ -547,18 +547,18 @@ For information about how the data model can be extended, see
 Document
       </h2>
       <p>
-A DID resolves to a DID Document. This is the concrete serialization of
+A DID resolves to a <a>DID Document</a>. This is the concrete serialization of
 the data model, according to a particular syntax (see
-<a href="#did-document-syntax"></a>). The DID Document contains attributes
+<a href="#did-document-syntax"></a>). The <a>DID Document</a> contains attributes
 or claims about the <a href="#did-subject"></a>, and the DID itself is
 contained in the <code>id</code> property.
       </p>
       <p>
-The properties that can be present in a DID Document are detailed
+The properties that can be present in a <a>DID Document</a> are detailed
 further in <a href="#did-documents"></a>.
       </p>
       <p>
-The properties present in a DID Document can be updated according to
+The properties present in a <a>DID Document</a> can be updated according to
 the applicable <a href="#did-methods"></a>.
       </p>
     </section>
@@ -568,8 +568,8 @@ the applicable <a href="#did-methods"></a>.
 Keys
       </h2>
       <p>
-One or more <a href="#public-keys"></a> can be included in a DID
-Document using, for example, the <code>publicKey</code> or <code>authentication</code>
+One or more <a href="#public-keys"></a> can be included in a <a>DID
+Document</a> using, for example, the <code>publicKey</code> or <code>authentication</code>
 properties depending on what they are to be used for. Each public key
 has an identifier (<code>id</code>) of its own, a <code>type</code>,
 and a <code>controller</code>, as well as other properties which
@@ -582,10 +582,10 @@ depend on what type of key it is.
 Services
       </h2>
       <p>
-A DID Document can contain pointers to services using the <code>
-service</code> property. Services can be anything the DID Subject
+A <a>DID Document</a> can contain pointers to services using the <code>
+service</code> property. Services can be anything the <a>DID Subject</a>
 wishes to advertise, for example other ways to interact with
-the DID Subject. Each service has its own <code>id</code> and
+the <a>DID Subject</a>. Each service has its own <code>id</code> and
 <code>type</code>, as well as a <code>serviceEndpoint</code> with a
 URI or further properties describing the service.
       </p>


### PR DESCRIPTION
The data model section is empty, so I added basic information under each heading with the expectation that it'll be filled out with more detail and probably diagrams at a later date. But at least it's not empty any more. I tried to avoid any controversial language and keep it simple in the hopes that this doesn't generate too much discussion at this late stage.

ALTERNATIVE PR: https://github.com/w3c-ccg/did-spec/pull/256 which removes the data model section entirely. Use this if the contents of this PR are going to be too controversial to merge fast.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/did-spec/pull/257.html" title="Last updated on Aug 8, 2019, 9:22 PM UTC (b984d61)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/did-spec/257/c9640fd...b984d61.html" title="Last updated on Aug 8, 2019, 9:22 PM UTC (b984d61)">Diff</a>