### PR TITLE
Add publicKeyHex as a valid publicKey format

### DIFF
--- a/contexts/did-v0.11.jsonld
+++ b/contexts/did-v0.11.jsonld
@@ -50,6 +50,7 @@
     "publicKey": {"@id": "sec:publicKey", "@type": "@id", "@container": "@set"},
     "publicKeyBase58": "sec:publicKeyBase58",
     "publicKeyPem": "sec:publicKeyPem",
+    "publicKeyHex": "sec:publicKeyHex",
     "revoked": {"@id": "sec:revoked", "@type": "xsd:dateTime"},
     "service": {"@id": "didv:service", "@type": "@id", "@container": "@set"},
     "serviceEndpoint": {"@id": "didv:serviceEndpoint", "@type": "@id"},

--- a/contexts/did-v0.12.jsonld
+++ b/contexts/did-v0.12.jsonld
@@ -50,6 +50,7 @@
     "publicKey": {"@id": "sec:publicKey", "@type": "@id", "@container": "@set"},
     "publicKeyBase58": "sec:publicKeyBase58",
     "publicKeyPem": "sec:publicKeyPem",
+    "publicKeyHex": "sec:publicKeyHex",
     "revoked": {"@id": "sec:revoked", "@type": "xsd:dateTime"},
     "service": {"@id": "didv:service", "@type": "@id", "@container": "@set"},
     "serviceEndpoint": {"@id": "didv:serviceEndpoint", "@type": "@id"},

--- a/contexts/did-v0.12.jsonld
+++ b/contexts/did-v0.12.jsonld
@@ -1,6 +1,6 @@
 {
   "@context": {
-    "@version": 1.2,
+    "@version": 1.1,
     "id": "@id",
     "type": "@type",
 

--- a/contexts/did-v0.12.jsonld
+++ b/contexts/did-v0.12.jsonld
@@ -1,6 +1,6 @@
 {
   "@context": {
-    "@version": 1.1,
+    "@version": 1.2,
     "id": "@id",
     "type": "@type",
 


### PR DESCRIPTION
fixes #152 

Added publicKeyHex as a valid publicKey format

The fact that `publicKeyHex` is missing from the did spec as a valid `publicKey` format is preventing us from adding [did:elem](https://github.com/decentralized-identity/element) to the [universal resolver](https://uniresolver.io/)

Not sure if can just edit the v0.11 file or if I should create a v0.12, let me know!